### PR TITLE
refactor(#44): heachi core auth

### DIFF
--- a/heachi-core/auth-api/src/main/java/com/heachi/auth/api/controller/auth/AuthController.java
+++ b/heachi-core/auth-api/src/main/java/com/heachi/auth/api/controller/auth/AuthController.java
@@ -48,12 +48,7 @@ public class AuthController {
             @RequestParam("code") String code,
             @RequestParam("state") String state,
             HttpServletRequest request) {
-        String requestState = request.getSession().getId();
-
-        // state 값 유효성 검증
-        if (!state.equals(requestState)) {
-            throw new OAuthException(ExceptionMessage.OAUTH_INVALID_STATE);
-        }
+        // state 값 검증 (redis)
 
         AuthServiceLoginResponse loginResponse = authService.login(platformType, code, request.getSession().getId());
 
@@ -71,9 +66,6 @@ public class AuthController {
 
     @GetMapping("/info")
     public JsonResult<UserSimpleInfoResponse> userInfo(@AuthenticationPrincipal User user) {
-        if (user.getRole() == UNAUTH) {
-            throw new AuthException(ExceptionMessage.AUTH_UNAUTHORIZED);
-        }
 
         return JsonResult.successOf(UserSimpleInfoResponse.of(user));
     }

--- a/heachi-core/auth-api/src/main/java/com/heachi/auth/api/controller/auth/request/AuthRegisterRequest.java
+++ b/heachi-core/auth-api/src/main/java/com/heachi/auth/api/controller/auth/request/AuthRegisterRequest.java
@@ -3,6 +3,7 @@ package com.heachi.auth.api.controller.auth.request;
 import com.heachi.mysql.define.user.constant.UserRole;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
@@ -17,9 +18,11 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class AuthRegisterRequest {
     @NotEmpty
+    @Email
     private String email;
 
     @Enumerated(EnumType.STRING)
+    @NotNull
     private UserRole role;
 
     // 숫자 값이므로 null이 아니어야 하니까 @NotEmpty 대신 @NotNull 사용 -> 빈 문자열("") 허용

--- a/heachi-core/auth-api/src/main/java/com/heachi/auth/api/controller/auth/response/UserSimpleInfoResponse.java
+++ b/heachi-core/auth-api/src/main/java/com/heachi/auth/api/controller/auth/response/UserSimpleInfoResponse.java
@@ -1,26 +1,19 @@
 package com.heachi.auth.api.controller.auth.response;
 
 import com.heachi.mysql.define.user.User;
-import com.heachi.mysql.define.user.constant.UserPlatformType;
 import com.heachi.mysql.define.user.constant.UserRole;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 public class UserSimpleInfoResponse {
-    private Long id;
-    private String platformId;
-    private UserPlatformType platformType;
     private UserRole role;
     private String name;
     private String email;
     private String profileImageUrl;
 
     @Builder
-    private UserSimpleInfoResponse(Long id, String platformId, UserPlatformType platformType, UserRole role, String name, String email, String profileImageUrl) {
-        this.id = id;
-        this.platformId = platformId;
-        this.platformType = platformType;
+    private UserSimpleInfoResponse(UserRole role, String name, String email, String profileImageUrl) {
         this.role = role;
         this.name = name;
         this.email = email;
@@ -29,9 +22,6 @@ public class UserSimpleInfoResponse {
 
     public static UserSimpleInfoResponse of(User user) {
         return UserSimpleInfoResponse.builder()
-                .id(user.getId())
-                .platformId(user.getPlatformId())
-                .platformType(user.getPlatformType())
                 .role(user.getRole())
                 .name(user.getName())
                 .email(user.getEmail())

--- a/heachi-core/auth-api/src/main/java/com/heachi/auth/config/filter/JwtAuthenticationFilter.java
+++ b/heachi-core/auth-api/src/main/java/com/heachi/auth/config/filter/JwtAuthenticationFilter.java
@@ -99,7 +99,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private void jwtExceptionHandler(HttpServletResponse response, ExceptionMessage message) throws IOException {
         response.setStatus(HttpStatus.OK.value());
         response.setCharacterEncoding("utf-8");
-        response.setCharacterEncoding(MediaType.APPLICATION_JSON_VALUE);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.getWriter().write(objectMapper.writeValueAsString(JsonResult.failOf(message.getText())));
     }
 }

--- a/heachi-core/auth-api/src/main/java/com/heachi/auth/config/filter/JwtAuthenticationFilter.java
+++ b/heachi-core/auth-api/src/main/java/com/heachi/auth/config/filter/JwtAuthenticationFilter.java
@@ -5,6 +5,9 @@ import com.heachi.admin.common.exception.ExceptionMessage;
 import com.heachi.admin.common.exception.jwt.JwtException;
 import com.heachi.admin.common.response.JsonResult;
 import com.heachi.auth.api.service.jwt.JwtService;
+import com.heachi.mysql.define.user.User;
+import com.heachi.mysql.define.user.constant.UserRole;
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.UnsupportedJwtException;
@@ -53,22 +56,26 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             token = authHeader.substring(7);
             userEmail = jwtService.extractUsername(token);
 
-            // token의 claims에 userEmail이 있는데, 인증정보가 없는 경우 -> 토큰 생성해주기
-            if (userEmail != null && SecurityContextHolder.getContext().getAuthentication() == null) {
-                UserDetails userDetails = userDetailsService.loadUserByUsername(userEmail); // 유저 이메일 있는지 확인
+            // token의 claims에 userEmail이 있는지 체크, 토큰이 유효한지 체크
+            if (userEmail != null && jwtService.isTokenValid(token, userEmail)) {
+                Claims claims = jwtService.extractAllClaims(token);
+                UserDetails userDetails = User.builder()
+                        .email(userEmail)
+                        .role(UserRole.valueOf(claims.get("role", String.class)))
+                        .name(claims.get("name", String.class))
+                        .profileImageUrl(claims.get("profileImageUrl", String.class))
+                        .build();
 
-                if (jwtService.isTokenValid(token, userDetails)) {
-                    UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
-                            userDetails,
-                            null,
-                            userDetails.getAuthorities()
-                    );
+                UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
+                        userDetails,
+                        null,
+                        userDetails.getAuthorities()
+                );
 
-                    authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
 
-                    // SecurityContext에 Authenticaiton 등록
-                    SecurityContextHolder.getContext().setAuthentication(authToken);
-                }
+                // SecurityContext에 Authenticaiton 등록
+                SecurityContextHolder.getContext().setAuthentication(authToken);
             }
             filterChain.doFilter(request, response);
         } catch (ExpiredJwtException e){

--- a/heachi-core/auth-api/src/test/java/com/heachi/auth/api/controller/auth/AuthControllerTest.java
+++ b/heachi-core/auth-api/src/test/java/com/heachi/auth/api/controller/auth/AuthControllerTest.java
@@ -171,7 +171,7 @@ class AuthControllerTest extends TestConfig {
                 .build();
 
         mockMvc.perform(
-                        post("/auth/KAKAO/register")
+                        post("/auth/register")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(JsonMapper.builder().build().writeValueAsString(request)))
                 .andExpect(status().isOk())
@@ -185,18 +185,18 @@ class AuthControllerTest extends TestConfig {
         // given
         // 유효성 검사 실패하는 request
         AuthRegisterRequest request = AuthRegisterRequest.builder()
-                .role(null)
+                .role(UserRole.USER) // userRole null
                 .email("1-203-102-3") // 잘못된 형식의 email
                 .phoneNumber("01012341234")
                 .build();
 
         mockMvc.perform(
-                        post("/auth/KAKAO/register")
+                        post("/auth/register")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(JsonMapper.builder().build().writeValueAsString(request)))
                 // .andExpect(status().isBadRequest());
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.resCode").value(400))
-                .andExpect(jsonPath("$.resMsg").value("email: 이메일 형식을 맞춰야합니다"));
+                .andExpect(jsonPath("$.resMsg").value("email: must be a well-formed email address"));
     }
 }

--- a/heachi-core/auth-api/src/test/java/com/heachi/auth/api/service/auth/AuthServiceTest.java
+++ b/heachi-core/auth-api/src/test/java/com/heachi/auth/api/service/auth/AuthServiceTest.java
@@ -79,7 +79,7 @@ class AuthServiceTest extends TestConfig {
 
         AuthServiceLoginResponse login = authService.login(platformType, code, state);     // 로그인 프로세스
         User findUser = userRepository.findByEmail(email).get();                  // 로그인한 사용자 찾기
-        boolean tokenValid = jwtService.isTokenValid(login.getToken(), findUser);   // 발행한 토큰 검증
+        boolean tokenValid = jwtService.isTokenValid(login.getToken(), findUser.getUsername());   // 발행한 토큰 검증
 
         // then
         assertThat(tokenValid).isTrue();
@@ -227,7 +227,7 @@ class AuthServiceTest extends TestConfig {
         AuthServiceLoginResponse response = authService.register(request);
 
         User savedUser = userRepository.findByEmail(request.getEmail()).get();
-        boolean tokenValid = jwtService.isTokenValid(response.getToken(), savedUser);   // 발행한 토큰 검증
+        boolean tokenValid = jwtService.isTokenValid(response.getToken(), savedUser.getUsername());   // 발행한 토큰 검증
 
 
         // then

--- a/heachi-core/auth-api/src/test/java/com/heachi/auth/api/service/jwt/JwtServiceTest.java
+++ b/heachi-core/auth-api/src/test/java/com/heachi/auth/api/service/jwt/JwtServiceTest.java
@@ -1,5 +1,6 @@
 package com.heachi.auth.api.service.jwt;
 
+import com.heachi.admin.common.exception.jwt.JwtException;
 import com.heachi.auth.TestConfig;
 import com.heachi.mysql.define.user.User;
 import com.heachi.mysql.define.user.constant.UserRole;
@@ -46,7 +47,7 @@ class JwtServiceTest extends TestConfig {
         User savedUser = userRepository.save(user);
 
         // when
-        assertThatThrownBy(() -> jwtService.isTokenValid(malformedToken, savedUser))
+        assertThatThrownBy(() -> jwtService.isTokenValid(malformedToken, savedUser.getUsername()))
                 .isInstanceOf(MalformedJwtException.class); // then
     }
 
@@ -64,7 +65,7 @@ class JwtServiceTest extends TestConfig {
         String expiredToken = jwtService.generateToken(new HashMap<>(), user, new Date());
 
         // then
-        assertThatThrownBy(() -> jwtService.isTokenValid(expiredToken, savedUser))
+        assertThatThrownBy(() -> jwtService.isTokenValid(expiredToken, savedUser.getUsername()))
                 .isInstanceOf(ExpiredJwtException.class);
 
     }
@@ -91,7 +92,7 @@ class JwtServiceTest extends TestConfig {
 
         // then
         System.out.println("token = " + token);
-        boolean result = jwtService.isTokenValid(token, savedUser);
+        boolean result = jwtService.isTokenValid(token, savedUser.getUsername());
         assertThat(result).isTrue();
     }
 
@@ -118,7 +119,7 @@ class JwtServiceTest extends TestConfig {
 
 
         // then
-        boolean result = jwtService.isTokenValid(token, savedUser);
+        boolean result = jwtService.isTokenValid(token, savedUser.getUsername());
         assertThat(result).isTrue();
         assertAll(
                 () -> assertThat(claims.getSubject()).isEqualTo("kimminsu@dankook.ac.kr"),
@@ -150,7 +151,33 @@ class JwtServiceTest extends TestConfig {
 
 
         // then
-        boolean result = jwtService.isTokenValid(token, savedUser);
+        boolean result = jwtService.isTokenValid(token, savedUser.getUsername());
         assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 UserRole을 넣었을때 오류 발생")
+    void notexistUserRoleException() {
+        // given
+        User user = User.builder()
+                .name("김민수")
+                .role(null)
+                .email("kimminsu@dankook.ac.kr")
+                .profileImageUrl("https://google.com")
+                .build();
+        User savedUser = userRepository.save(user);
+
+        HashMap<String, String> map = new HashMap<>();
+        map.put("role", null);
+        map.put("name", savedUser.getName());
+        map.put("profileImageUrl", savedUser.getProfileImageUrl());
+        String token = jwtService.generateToken(map, savedUser);
+
+        // when
+        assertThatThrownBy(() -> jwtService.isTokenValid(token, savedUser.getUsername()))
+                // then
+                .isInstanceOf(JwtException.class);
+
+
     }
 }


### PR DESCRIPTION
## 작업 내용

- [x] JWT Authentication Filter 로직에서 데이터베이스를 거치는 로직 수정
- [x] Claims 를 통한 UserInfo 검색 (UNAUTH도 사용 가능)
- [x] Login State 검증 로직 일단 삭제 (Redis를 통해 관리 예정)

### TEST
- [x] 존재하지 않는 UserRole을 넣었을때 오류 발생
- [x] userSimpleInfo 테스트, role, name, email, profileImageUrl이 리턴된다.
- [x] userSimpleInfo 실패 테스트, 잘못된 Token을 넣으면 오류를 뱉는다.

<br/><br/>

## 리뷰 중점사항

- JWT Filter 로직 확인해주세요

<br/><br/>

## 관련 이슈

#44 