### PR TITLE
feat(#43): 회원 탈퇴 기능

### DIFF
--- a/heachi-core/auth-api/src/main/java/com/heachi/auth/api/controller/auth/AuthController.java
+++ b/heachi-core/auth-api/src/main/java/com/heachi/auth/api/controller/auth/AuthController.java
@@ -69,4 +69,11 @@ public class AuthController {
 
         return JsonResult.successOf(UserSimpleInfoResponse.of(user));
     }
+
+    @PostMapping("/delete")
+    public JsonResult<?> userDelete(@AuthenticationPrincipal User user) {
+        authService.userDelete(user.getEmail());
+
+        return JsonResult.successOf();
+    }
 }

--- a/heachi-core/auth-api/src/main/java/com/heachi/auth/api/service/auth/AuthService.java
+++ b/heachi-core/auth-api/src/main/java/com/heachi/auth/api/service/auth/AuthService.java
@@ -110,4 +110,20 @@ public class AuthService {
         // 로그인 반환 객체 생성
         return token;
     }
+
+    @Transactional
+    public void userDelete(String email) {
+        User user = userRepository.findByEmail(email).orElseThrow(() -> {
+            log.warn(">>>> User Delete Fail : {}", ExceptionMessage.AUTH_NOT_FOUND.getText());
+            throw new AuthException(ExceptionMessage.AUTH_NOT_FOUND);
+        });
+
+        try {
+            userRepository.deleteById(user.getId());
+            log.info(">>>> {} Info is Deleted.", user.getName());
+        } catch (IllegalArgumentException e) {
+            log.error(">>>> ID = {} : 계정 삭제에 실패했습니다.", user.getId());
+            throw new AuthException(ExceptionMessage.AUTH_DELETE_FAIL);
+        }
+    }
 }

--- a/heachi-core/auth-api/src/test/java/com/heachi/auth/api/controller/auth/AuthControllerTest.java
+++ b/heachi-core/auth-api/src/test/java/com/heachi/auth/api/controller/auth/AuthControllerTest.java
@@ -252,4 +252,34 @@ class AuthControllerTest extends TestConfig {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.resCode").value(400));
     }
+
+    @Test
+    @DisplayName("올바른 사용자의 토큰으로 사용자 계정 탈퇴 요청을 하면, 계정이 삭제된다.")
+    void validUserTokenRequestWithDrawThenUserDelete() throws Exception {
+        // given
+        User user = User.builder()
+                .platformId("12345")
+                .platformType(KAKAO)
+                .email("kms@kakao.com")
+                .name("김민수")
+                .profileImageUrl("google.co.kr")
+                .role(UserRole.USER)
+                .build();
+        userRepository.saveAndFlush(user);
+
+        AuthServiceRegisterRequest request = AuthServiceRegisterRequest.builder()
+                .role(UserRole.USER)
+                .phoneNumber("010-0000-0000")
+                .email(user.getEmail())
+                .build();
+        String token = authService.register(request).getToken();
+
+        // when
+        mockMvc.perform(get("/auth/delete")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer " + token))
+                // then
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resCode").value(200));
+    }
 }

--- a/heachi-core/auth-api/src/test/java/com/heachi/auth/api/service/auth/AuthServiceTest.java
+++ b/heachi-core/auth-api/src/test/java/com/heachi/auth/api/service/auth/AuthServiceTest.java
@@ -1,5 +1,6 @@
 package com.heachi.auth.api.service.auth;
 
+import com.heachi.admin.common.exception.auth.AuthException;
 import com.heachi.admin.common.exception.oauth.OAuthException;
 import com.heachi.auth.TestConfig;
 import com.heachi.auth.api.service.auth.request.AuthServiceRegisterRequest;
@@ -269,5 +270,38 @@ class AuthServiceTest extends TestConfig {
         assertThrows(RuntimeException.class, () -> {
             authService.register(request);
         });
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 Email로 계정삭제를 진행할 수 없다.")
+    void isNotProcessingWhenEmailIsNotExist() {
+        // given
+        String invalidEmail = "abcdd@abc.com";
+
+        // when
+        assertThrows(AuthException.class,
+                () -> authService.userDelete(invalidEmail));
+    }
+
+    @Test
+    @DisplayName("존재하는 계정의 Email로 계정삭제를 진행할 수 있다.")
+    void successProcessingWhenEmailIsExistInDB() {
+        // given
+        User user = User.builder()
+                .platformId("12345")
+                .platformType(KAKAO)
+                .email("kms@kakao.com")
+                .name("김민수")
+                .profileImageUrl("google.co.kr")
+                .role(UserRole.USER)
+                .build();
+        userRepository.save(user);
+
+        // when
+        authService.userDelete("kms@kakao.com");
+        Optional<User> byEmail = userRepository.findByEmail("kms@kakao.com");
+
+        // then
+        assertThat(byEmail.isEmpty()).isTrue();
     }
 }

--- a/heachi-support/common/src/main/java/com/heachi/admin/common/exception/ExceptionMessage.java
+++ b/heachi-support/common/src/main/java/com/heachi/admin/common/exception/ExceptionMessage.java
@@ -24,6 +24,8 @@ public enum ExceptionMessage {
     AUTH_DUPLICATE_UNAUTH_REGISTER("중복된 회원가입 요청입니다."),
     AUTH_SERVER_NOT_RESPOND("인증 서버가 응답하지 않습니다."),
     AUTH_UNAUTHORIZED("현재 권한으로 실행할 수 없는 요청입니다."),
+    AUTH_NOT_FOUND("계정 정보를 찾을 수 없습니다."),
+    AUTH_DELETE_FAIL("계정 삭제에 실패했습니다."),
 
     // NotifyException
     NOTIFY_NOT_FOUND("해당 아이디의 알림을 찾을 수 없습니다."),


### PR DESCRIPTION
## 작업 내용

- [x] 회원 탈퇴 기능 구현

### 테스트
- [x] 존재하지 않는 Email로 계정삭제를 진행할 수 없다.
- [x] 존재하는 계정의 Email로 계정삭제를 진행할 수 있다.
- [x] 올바른 사용자의 토큰으로 사용자 계정 탈퇴 요청을 하면, 계정이 삭제된다.
<br/><br/>

## 리뷰 중점사항

- 기본적인 회원 탈퇴 기능을 구현했습니다. 추후 탈퇴 로직에 추가할 작업이 있으면 추가하겠습니다~

<br/><br/>

## 관련 이슈

#43