### PR TITLE
feat(#79): housework add

### DIFF
--- a/heachi-core/housework-api/src/main/java/com/heachi/housework/api/controller/housework/info/HouseworkInfoController.java
+++ b/heachi-core/housework-api/src/main/java/com/heachi/housework/api/controller/housework/info/HouseworkInfoController.java
@@ -26,7 +26,7 @@ public class HouseworkInfoController {
         // Auth 서버로 요청자 인증 요청 - 해당 그룹원인지 판별하고 상태가 ACCEPT인지 확인
         try {
             authExternalService.userAuthenticateAndGroupMatch(authorization, groupId);
-            houseworkInfoService.createHouseworkInfo(HouseworkInfoCreateServiceRequest.of(request));
+            houseworkInfoService.createHouseworkInfo(HouseworkInfoCreateServiceRequest.of(request, groupId));
 
             return JsonResult.successOf("Housework Create Success.");
         } catch (HeachiException e) {

--- a/heachi-core/housework-api/src/main/java/com/heachi/housework/api/service/housework/info/HouseworkInfoService.java
+++ b/heachi-core/housework-api/src/main/java/com/heachi/housework/api/service/housework/info/HouseworkInfoService.java
@@ -96,30 +96,31 @@ public class HouseworkInfoService {
                             todoListRepository.save(todoList);
                             log.info(">>>> dirtyBit Checking TodoList id: {}", todoList.getId());
                         });
+            } else {
 
-                return ;
+                // HOUSEWORK_INFO 저장
+                HouseworkInfo houseworkInfo = houseworkInfoRepository.save(HouseworkInfo.builder()
+                        .houseworkCategory(category)
+                        .title(request.getTitle())
+                        .detail(request.getDetail())
+                        .type(request.getType())
+                        .dayDate(request.getDayDate())
+                        .weekDate(request.getWeekDate())
+                        .monthDate(request.getMonthDate())
+                        .endTime(request.getEndTime())
+                        .build());
+                log.info(">>>> HouseworkInfo Create: {}", houseworkInfo.getId());
+
+                groupMemberList.stream()
+                        .map(gm -> HouseworkMember.builder()
+                                .groupMember(gm)
+                                .houseworkInfo(houseworkInfo)
+                                .build())
+                        // HOUSEWORK_MEMBER 저장
+                        .forEach(houseworkMemberRepository::save);
+
+                // TODO: findByGroupInfoId를 통해 해당 그룹의 캐싱된 객체 조회
             }
-
-            // HOUSEWORK_INFO 저장
-            HouseworkInfo houseworkInfo = houseworkInfoRepository.save(HouseworkInfo.builder()
-                    .houseworkCategory(category)
-                    .title(request.getTitle())
-                    .detail(request.getDetail())
-                    .type(request.getType())
-                    .dayDate(request.getDayDate())
-                    .weekDate(request.getWeekDate())
-                    .monthDate(request.getMonthDate())
-                    .endTime(request.getEndTime())
-                    .build());
-            log.info(">>>> HouseworkInfo Create: {}", houseworkInfo.getId());
-
-            groupMemberList.stream()
-                    .map(gm -> HouseworkMember.builder()
-                            .groupMember(gm)
-                            .houseworkInfo(houseworkInfo)
-                            .build())
-                    // HOUSEWORK_MEMBER 저장
-                    .forEach(houseworkMemberRepository::save);
 
         } catch (RuntimeException e) {
             log.warn(">>>> Housework Add Fail : {}", e.getMessage());

--- a/heachi-core/housework-api/src/main/java/com/heachi/housework/api/service/housework/info/request/HouseworkInfoCreateServiceRequest.java
+++ b/heachi-core/housework-api/src/main/java/com/heachi/housework/api/service/housework/info/request/HouseworkInfoCreateServiceRequest.java
@@ -24,10 +24,12 @@ public class HouseworkInfoCreateServiceRequest {
     private String monthDate;
     private LocalTime endTime;
 
+    private Long groupId;
+
     @Builder
     private HouseworkInfoCreateServiceRequest(List<Long> groupMemberIdList, Long houseworkCategoryId, String title,
                                              String detail, HouseworkPeriodType type, LocalDate dayDate, String weekDate,
-                                             String monthDate, LocalTime endTime) {
+                                             String monthDate, LocalTime endTime, Long groupId) {
         this.groupMemberIdList = groupMemberIdList == null ? new ArrayList<>() : groupMemberIdList;
         this.houseworkCategoryId = houseworkCategoryId;
         this.title = title;
@@ -37,9 +39,10 @@ public class HouseworkInfoCreateServiceRequest {
         this.weekDate = weekDate;
         this.monthDate = monthDate;
         this.endTime = endTime;
+        this.groupId = groupId;
     }
 
-    public static HouseworkInfoCreateServiceRequest of(HouseworkInfoCreateRequest request) {
+    public static HouseworkInfoCreateServiceRequest of(HouseworkInfoCreateRequest request, Long groupId) {
 
         return HouseworkInfoCreateServiceRequest.builder()
                 .groupMemberIdList(request.getGroupMemberIdList())
@@ -51,6 +54,7 @@ public class HouseworkInfoCreateServiceRequest {
                 .weekDate(request.getWeekDate())
                 .monthDate(request.getMonthDate())
                 .endTime(request.getEndTime())
+                .groupId(groupId)
                 .build();
     }
 }

--- a/heachi-support/common/src/main/java/com/heachi/admin/common/exception/group/info/GroupInfoException.java
+++ b/heachi-support/common/src/main/java/com/heachi/admin/common/exception/group/info/GroupInfoException.java
@@ -1,0 +1,10 @@
+package com.heachi.admin.common.exception.group.info;
+
+import com.heachi.admin.common.exception.ExceptionMessage;
+import com.heachi.admin.common.exception.HeachiException;
+
+public class GroupInfoException extends HeachiException {
+    public GroupInfoException(ExceptionMessage message) {
+        super(message.getText());
+    }
+}


### PR DESCRIPTION
## 작업 내용

- [x] Caching Data DirtyChekcing 구현

### 테스트
- [x]  딱 한번하는 집안일의 경우, HOUSEWORK_INFO가 생성되지 않고, HOUSEWORK_TODO가 바로 생성된다.
만약, Redis에 이미 캐싱되어있던 TodoList일 경우 DirtyBit가 Check로 바뀐다.

<br/><br/>

## 리뷰 중점사항

- groupId가 필요해서 Request Dto에 추가 필드를 넣었습니다.

<br/><br/>

## 관련 이슈

#79