### PR TITLE
feat(#76): housework group

### DIFF
--- a/heachi-core/housework-api/src/main/java/com/heachi/housework/api/controller/group/info/GroupInfoController.java
+++ b/heachi-core/housework-api/src/main/java/com/heachi/housework/api/controller/group/info/GroupInfoController.java
@@ -1,0 +1,40 @@
+package com.heachi.housework.api.controller.group.info;
+
+import com.heachi.admin.common.response.JsonResult;
+import com.heachi.external.clients.auth.response.UserInfoResponse;
+import com.heachi.housework.api.controller.group.info.request.GroupInfoCreateRequest;
+import com.heachi.housework.api.service.auth.AuthExternalService;
+import com.heachi.housework.api.service.group.info.GroupInfoService;
+import com.heachi.housework.api.service.group.info.request.GroupInfoCreateServiceRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/group/info")
+public class GroupInfoController {
+
+    private final AuthExternalService authExternalService;
+    private final GroupInfoService groupInfoService;
+
+    @PostMapping("/")
+    public JsonResult<?> createGroupInfo(@RequestHeader(name = "Authorization") String authorization,
+                                         @Valid @RequestBody GroupInfoCreateRequest request) {
+        // 유저 인증
+        UserInfoResponse userInfoResponse = authExternalService.userAuthenticate(authorization);
+        // GroupInfo 생성
+        groupInfoService.createGroupInfo(GroupInfoCreateServiceRequest.builder()
+                .bgColor(request.getBgColor())
+                .colorCode(request.getColorCode())
+                .gradient(request.getGradient())
+                .name(request.getName())
+                .info(request.getInfo())
+                .email(userInfoResponse.getEmail())
+                .build());
+
+        return JsonResult.successOf();
+    }
+}

--- a/heachi-core/housework-api/src/main/java/com/heachi/housework/api/controller/group/info/request/GroupInfoCreateRequest.java
+++ b/heachi-core/housework-api/src/main/java/com/heachi/housework/api/controller/group/info/request/GroupInfoCreateRequest.java
@@ -1,0 +1,27 @@
+package com.heachi.housework.api.controller.group.info.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.hibernate.validator.constraints.Length;
+
+@Getter
+@ToString
+@NoArgsConstructor
+public class GroupInfoCreateRequest {
+    @NotEmpty
+    private String bgColor;     // 그룹 배경색
+
+    @NotEmpty
+    private String colorCode;   // 그룹 색상코드
+
+    @NotEmpty
+    private String gradient;    // 그룹의 css 속성
+
+    @NotEmpty
+    private String name;        // 그룹 이름
+
+    @Length(max = 512)
+    private String info;        // 그룹 소개
+}

--- a/heachi-core/housework-api/src/main/java/com/heachi/housework/api/service/group/info/GroupInfoService.java
+++ b/heachi-core/housework-api/src/main/java/com/heachi/housework/api/service/group/info/GroupInfoService.java
@@ -1,0 +1,56 @@
+package com.heachi.housework.api.service.group.info;
+
+import com.heachi.admin.common.exception.ExceptionMessage;
+import com.heachi.admin.common.exception.user.UserException;
+import com.heachi.housework.api.service.group.info.request.GroupInfoCreateServiceRequest;
+import com.heachi.mysql.define.group.info.GroupInfo;
+import com.heachi.mysql.define.group.info.repository.GroupInfoRepository;
+import com.heachi.mysql.define.group.member.GroupMember;
+import com.heachi.mysql.define.group.member.constant.GroupMemberRole;
+import com.heachi.mysql.define.group.member.constant.GroupMemberStatus;
+import com.heachi.mysql.define.group.member.repository.GroupMemberRepository;
+import com.heachi.mysql.define.user.User;
+import com.heachi.mysql.define.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GroupInfoService {
+
+    private final UserRepository userRepository;
+    private final GroupInfoRepository groupInfoRepository;
+    private final GroupMemberRepository groupMemberRepository;
+
+    @Transactional(readOnly = false)
+    public void createGroupInfo(GroupInfoCreateServiceRequest request) {
+        // User 가져오기
+        User user = userRepository.findByEmail(request.getEmail()).orElseThrow(() -> {
+            log.warn(">>>> {} : {}", ExceptionMessage.USER_NOT_FOUND.getText(), request.getEmail());
+
+            throw new UserException(ExceptionMessage.USER_NOT_FOUND);
+        });
+
+        // GroupInfo 생성하기
+        GroupInfo groupInfo = groupInfoRepository.save(GroupInfo.builder()
+                .user(user) // 생성하는 사람을 자동으로 그룹장으로 임명
+                .bgColor(request.getBgColor())
+                .colorCode(request.getColorCode())
+                .gradient(request.getGradient())
+                .name(request.getName())
+                .info(request.getInfo())
+                .build());
+
+        // GroupMember 생성하기
+        groupMemberRepository.save(GroupMember.builder()
+                .groupInfo(groupInfo)
+                .user(user)
+                .role(GroupMemberRole.GROUP_ADMIN)  // 그룹장
+                .status(GroupMemberStatus.ACCEPT)   // 그룹원
+                .build());
+    }
+}

--- a/heachi-core/housework-api/src/main/java/com/heachi/housework/api/service/group/info/request/GroupInfoCreateServiceRequest.java
+++ b/heachi-core/housework-api/src/main/java/com/heachi/housework/api/service/group/info/request/GroupInfoCreateServiceRequest.java
@@ -1,0 +1,27 @@
+package com.heachi.housework.api.service.group.info.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class GroupInfoCreateServiceRequest {
+
+    private String bgColor;     // 그룹 배경색
+    private String colorCode;   // 그룹 색상코드
+    private String gradient;    // 그룹의 css 속성
+    private String name;        // 그룹 이름
+    private String info;        // 그룹 소개
+
+    private String email;       // 유저 이메일
+
+    @Builder
+    private GroupInfoCreateServiceRequest(String bgColor, String colorCode, String gradient,
+                                          String name, String info, String email) {
+        this.bgColor = bgColor;
+        this.colorCode = colorCode;
+        this.gradient = gradient;
+        this.name = name;
+        this.info = info;
+        this.email = email;
+    }
+}

--- a/heachi-core/housework-api/src/test/java/com/heachi/housework/api/service/group/info/GroupInfoServiceTest.java
+++ b/heachi-core/housework-api/src/test/java/com/heachi/housework/api/service/group/info/GroupInfoServiceTest.java
@@ -1,0 +1,85 @@
+package com.heachi.housework.api.service.group.info;
+
+import com.heachi.admin.common.exception.user.UserException;
+import com.heachi.housework.TestConfig;
+import com.heachi.housework.api.service.group.info.request.GroupInfoCreateServiceRequest;
+import com.heachi.mysql.define.group.info.GroupInfo;
+import com.heachi.mysql.define.group.info.repository.GroupInfoRepository;
+import com.heachi.mysql.define.group.member.GroupMember;
+import com.heachi.mysql.define.group.member.repository.GroupMemberRepository;
+import com.heachi.mysql.define.user.User;
+import com.heachi.mysql.define.user.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class GroupInfoServiceTest extends TestConfig {
+
+    @Autowired private UserRepository userRepository;
+    @Autowired private GroupInfoRepository groupInfoRepository;
+    @Autowired private GroupMemberRepository groupMemberRepository;
+
+    @Autowired private GroupInfoService groupInfoService;
+
+    @AfterEach
+    void tearDown() {
+        groupMemberRepository.deleteAllInBatch();
+        groupInfoRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
+    }
+
+    @Test
+    @DisplayName("올바른 GroupInfoCreateServiceRequest를 넘기면, 요청한 유저가 관리자로 GroupInfo, GroupMember가 생성된다.")
+    void createGroupInfoSuccess() {
+        // given
+        User user = userRepository.save(generateUser());
+        var request = GroupInfoCreateServiceRequest.builder()
+                .bgColor("bgColor")
+                .colorCode("colorCode")
+                .gradient("gradient")
+                .name("name")
+                .info("info")
+                .email(user.getEmail())
+                .build();
+
+        // when
+        groupInfoService.createGroupInfo(request);
+        GroupInfo groupInfo = groupInfoRepository.findAll().get(0);
+        GroupMember groupMember = groupMemberRepository.findAll().get(0);
+
+        // then
+        assertThat(groupInfo.getUser().getId()).isEqualTo(user.getId());
+        assertThat(groupMember.getGroupInfo().getId()).isEqualTo(groupInfo.getId());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 유저 이메일일 경우, GroupInfo를 생성할 수 없다.")
+    void createGroupInfoFailWhenUserEmailNotFound() {
+        // given
+        var request = GroupInfoCreateServiceRequest.builder()
+                .bgColor("bgColor")
+                .colorCode("colorCode")
+                .gradient("gradient")
+                .name("name")
+                .info("info")
+                .email("kms@kakao.com")
+                .build();
+
+        // when & then
+        assertThrows(UserException.class ,() -> groupInfoService.createGroupInfo(request));
+
+        List<GroupInfo> groupInfoList = groupInfoRepository.findAll();
+        List<GroupMember> groupMemberList = groupMemberRepository.findAll();
+
+        assertThat(groupInfoList.size()).isEqualTo(0);
+        assertThat(groupMemberList.size()).isEqualTo(0);
+    }
+}

--- a/heachi-domain-mysql/src/main/java/com/heachi/mysql/define/group/info/GroupInfo.java
+++ b/heachi-domain-mysql/src/main/java/com/heachi/mysql/define/group/info/GroupInfo.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -48,13 +49,19 @@ public class GroupInfo extends BaseEntity {
     private String joinCode;    // 그룹 가입코드
 
     @Builder
-    private GroupInfo(User user, String bgColor, String colorCode, String gradient, String name, String info, String joinCode) {
+    private GroupInfo(User user, String bgColor, String colorCode, String gradient, String name, String info) {
         this.user = user;
         this.bgColor = bgColor;
         this.colorCode = colorCode;
         this.gradient = gradient;
         this.name = name;
         this.info = info;
-        this.joinCode = joinCode;
+        this.joinCode = rotateJoinCode();
+    }
+
+    public String rotateJoinCode() {
+        this.joinCode = UUID.randomUUID().toString().substring(0, 6);
+
+        return this.joinCode;
     }
 }

--- a/heachi-support/common/src/main/java/com/heachi/admin/common/exception/ExceptionMessage.java
+++ b/heachi-support/common/src/main/java/com/heachi/admin/common/exception/ExceptionMessage.java
@@ -24,6 +24,9 @@ public enum ExceptionMessage {
     OAUTH_INVALID_TOKEN_URL("tokenURL이 정확하지 않습니다."),
     OAUTH_INVALID_ACCESS_TOKEN("잘못된 access_token 입니다."),
 
+    // USER
+    USER_NOT_FOUND("USER 정보를 찾을 수 없습니다."),
+
     // LoginState
     LOGINSTATE_IS_NOT_USE("해당 LoginState를 사용할 수 없습니다."),
     LOGINSTATE_INVALID_VALUE("LoginState 정보가 잘못되었습니다."),

--- a/heachi-support/common/src/main/java/com/heachi/admin/common/exception/user/UserException.java
+++ b/heachi-support/common/src/main/java/com/heachi/admin/common/exception/user/UserException.java
@@ -1,0 +1,10 @@
+package com.heachi.admin.common.exception.user;
+
+import com.heachi.admin.common.exception.ExceptionMessage;
+import com.heachi.admin.common.exception.HeachiException;
+
+public class UserException extends HeachiException {
+    public UserException(ExceptionMessage message) {
+        super(message.getText());
+    }
+}


### PR DESCRIPTION
## 작업 내용

- [x] 그룹 생성에 필요한 정보 받기
- [x] 그룹을 생성하면 자동으로 그룹 가입코드[6자리] 생성 (재생성 메소드도 만들어놓기)
- [x] 그룹을 생성하는 유저가 자동으로 그룹장으로 임명
- [x] GROUP_MEMBER에 자동으로 ACCEPT 상태로 유저를 등록해줘야함.
### 테스트
- [x] 올바른 GroupInfoCreateServiceRequest를 넘기면, 요청한 유저가 관리자로 GroupInfo, GroupMember가 생성된다.
- [x] 존재하지 않는 유저 이메일일 경우, GroupInfo를 생성할 수 없다.

<br/><br/>

## 리뷰 중점사항

<br/><br/>

## 관련 이슈

#76 