### PR TITLE
chore(#84): jib build

### DIFF
--- a/.github/workflows/CI_main_push.yml
+++ b/.github/workflows/CI_main_push.yml
@@ -58,5 +58,12 @@ jobs:
     # Jib을 이용한 도커 이미지 빌드 후 허브 푸쉬
     - name: 도커 이미지 빌드 & 도커 허브 푸쉬
       run: ./gradlew jib
-    
-    
+
+  deployment:
+    name: docker 배포
+    needs: build # depends on
+    runs-on: self-hosted
+
+    steps:
+      - name: docker-compose 배포 스크립트
+        run: ${{ secrets.DOCKER_COMPOSE_DEPLOYMENT_SCRIPT }}

--- a/heachi-core/auth-api/build.gradle
+++ b/heachi-core/auth-api/build.gradle
@@ -39,8 +39,12 @@ jib {
         image = 'eclipse-temurin:17-jre' // https://github.com/GoogleContainerTools/jib/issues/3483
         platforms {
             platform {
-                architecture = "arm64"
+                architecture = "amd64"
                 os = "linux"
+            }
+            platform {
+                architecture = 'arm64'
+                os = 'linux'
             }
         }
     }
@@ -54,7 +58,7 @@ jib {
     }
     container {
 
-        entrypoint = ['java', '-Dspring.profiles.active=prod', '-jar', 'heachi-auth-' + buildVersion + '.jar']
+        entrypoint = ['java', '-Dspring.profiles.active=prod', '-Duser.timezone=Aisa/Seoul', '-jar', 'heachi-auth-' + buildVersion + '.jar']
         jvmFlags = ['-Xms2048m', '-Xmx2048m', '-Xdebug', '-XshowSettings:vm', '-XX:+UnlockExperimentalVMOptions', '-XX:+UseContainerSupport']
         ports = ['8080']
         environment = [SPRING_OUTPUT_ANSI_ENABLED: "ALWAYS"]

--- a/heachi-core/housework-api/build.gradle
+++ b/heachi-core/housework-api/build.gradle
@@ -32,8 +32,12 @@ jib {
         image = 'eclipse-temurin:17-jre' // https://github.com/GoogleContainerTools/jib/issues/3483
         platforms {
             platform {
-                architecture = "arm64"
+                architecture = "amd64"
                 os = "linux"
+            }
+            platform {
+                architecture = 'arm64'
+                os = 'linux'
             }
         }
     }
@@ -47,7 +51,7 @@ jib {
     }
     container {
 
-        entrypoint = ['java', '-Dspring.profiles.active=prod', '-jar', 'heachi-housework-' + buildVersion + '.jar']
+        entrypoint = ['java', '-Dspring.profiles.active=prod', '-Duser.timezone=Aisa/Seoul', '-jar', 'heachi-housework-' + buildVersion + '.jar']
         jvmFlags = ['-Xms2048m', '-Xmx2048m', '-Xdebug', '-XshowSettings:vm', '-XX:+UnlockExperimentalVMOptions', '-XX:+UseContainerSupport']
         ports = ['8000']
         environment = [SPRING_OUTPUT_ANSI_ENABLED: "ALWAYS"]

--- a/heachi-notify/build.gradle
+++ b/heachi-notify/build.gradle
@@ -26,8 +26,12 @@ jib {
         image = 'eclipse-temurin:17-jre' // https://github.com/GoogleContainerTools/jib/issues/3483
         platforms {
             platform {
-                architecture = "arm64"
+                architecture = "amd64"
                 os = "linux"
+            }
+            platform {
+                architecture = 'arm64'
+                os = 'linux'
             }
         }
     }
@@ -41,7 +45,7 @@ jib {
     }
     container {
 
-        entrypoint = ['java', '-Dspring.profiles.active=prod', '-jar', 'heachi-notify-' + buildVersion + '.jar']
+        entrypoint = ['java', '-Dspring.profiles.active=prod', '-Duser.timezone=Aisa/Seoul', '-jar', 'heachi-notify-' + buildVersion + '.jar']
         jvmFlags = ['-Xms2048m', '-Xmx2048m', '-Xdebug', '-XshowSettings:vm', '-XX:+UnlockExperimentalVMOptions', '-XX:+UseContainerSupport']
         ports = ['8001']
         environment = [SPRING_OUTPUT_ANSI_ENABLED: "ALWAYS"]


### PR DESCRIPTION
## 📍 docker-compose.yml

```yaml
version: "3"
services:
  auth:
    image: ghdcksgml1/heachi-auth
    container_name: auth
    restart: unless-stopped
    ports:
      - "8080:8080"
    depends_on:
      - mysql
      - redis
    volumes:
      - ./log/auth/:/log

  notify:
    image: ghdcksgml1/heachi-notify
    container_name: notify
    restart: unless-stopped
    ports:
      - "8001:8001"
    depends_on:
      - mongodb
    volumes:
      - ./log/notify/:/log

  housework:
    image: ghdcksgml1/heachi-housework
    container_name: housework
    restart: unless-stopped
    ports:
      - "8000:8000"
    depends_on:
      - mysql
      - redis
    volumes:
      - ./log/housework/:/log

  mongodb:
    image: mongo:4.4
    container_name: mongodb
    restart: unless-stopped
    ports:
      - "27017"
    volumes:
      - ./volumes/mongodb:/data/db
    environment:
      - MONGO_INITDB_ROOT_USERNAME={ 유저이름 }
      - MONGO_INITDB_ROOT_PASSWORD={ 비밀번호 }
      - MONGO_INITDB_DATABASE={ 데이터베이스 이름 }

  mysql:
    image: mysql:8.0.32
    container_name: mysql
    restart: unless-stopped
    ports:
      - "3306"
    volumes:
      - ./volumes/mysql:/var/lib/mysql
    environment:
      - MYSQL_HOST=localhost
      - MYSQL_PORT=3306
      - MYSQL_ROOT_PASSWORD={ 비밀번호 }

  redis:
    image: redis:6.0
    container_name: redis
    command: redis-server --port 6379
    ports:
      - "6379"
    restart: unless-stopped
    volumes:
      - ./volumes/redis:/data

networks:
  nbbang-network:
    driver: bridge
```