### PR TITLE
feat(#75): group list

### DIFF
--- a/heachi-core/housework-api/src/main/java/com/heachi/housework/api/controller/group/info/GroupInfoController.java
+++ b/heachi-core/housework-api/src/main/java/com/heachi/housework/api/controller/group/info/GroupInfoController.java
@@ -34,6 +34,7 @@ public class GroupInfoController {
         UserInfoResponse userInfo = authExternalService.userAuthenticate(authorization);
 
         return JsonResult.successOf(groupInfoService.userGroupInfoList(userInfo.getEmail()));
+    }
 
     @PostMapping("/")
     public JsonResult<?> createGroupInfo(@RequestHeader(name = "Authorization") String authorization,

--- a/heachi-core/housework-api/src/main/java/com/heachi/housework/api/controller/group/info/GroupInfoController.java
+++ b/heachi-core/housework-api/src/main/java/com/heachi/housework/api/controller/group/info/GroupInfoController.java
@@ -1,0 +1,30 @@
+package com.heachi.housework.api.controller.group.info;
+
+import com.heachi.admin.common.response.JsonResult;
+import com.heachi.external.clients.auth.response.UserInfoResponse;
+import com.heachi.housework.api.service.auth.AuthExternalService;
+import com.heachi.housework.api.service.group.info.GroupInfoService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/group/info")
+public class GroupInfoController {
+
+    private final AuthExternalService authExternalService;
+    private final GroupInfoService groupInfoService;
+
+    // User가 가입한 Group 정보를 리턴한다.
+    @GetMapping("/list")
+    public JsonResult<?> userGroupInfoList(@RequestHeader(name = "Authorization") String authorization) {
+        UserInfoResponse userInfo = authExternalService.userAuthenticate(authorization);
+
+        return JsonResult.successOf(groupInfoService.userGroupInfoList(userInfo.getEmail()));
+    }
+}

--- a/heachi-core/housework-api/src/main/java/com/heachi/housework/api/service/group/info/GroupInfoService.java
+++ b/heachi-core/housework-api/src/main/java/com/heachi/housework/api/service/group/info/GroupInfoService.java
@@ -1,0 +1,79 @@
+package com.heachi.housework.api.service.group.info;
+
+import com.heachi.admin.common.exception.ExceptionMessage;
+import com.heachi.admin.common.exception.group.info.GroupInfoException;
+import com.heachi.housework.api.service.group.info.response.GroupInfoUserGroupServiceResponse;
+import com.heachi.mysql.define.group.info.repository.GroupInfoRepository;
+import com.heachi.mysql.define.group.info.repository.response.GroupInfoUserGroupResponse;
+import com.heachi.mysql.define.housework.todo.constant.HouseworkTodoStatus;
+import com.heachi.mysql.define.housework.todo.repository.HouseworkTodoRepository;
+import com.heachi.mysql.define.housework.todo.repository.response.HouseworkTodoCount;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class GroupInfoService {
+
+    private final GroupInfoRepository groupInfoRepository;
+    private final HouseworkTodoRepository houseworkTodoRepository;
+
+    public List<GroupInfoUserGroupServiceResponse> userGroupInfoList(String email) {
+
+        // 해당 유저가 속한 그룹 가져오기
+        List<GroupInfoUserGroupResponse> groupInfoList = groupInfoRepository.findGroupInfoUserGroupResponseListByUserEmail(email);
+        if (groupInfoList.isEmpty()) {
+            log.warn(">>>> 유저가 가입한 그룹이 존재하지 않습니다.");
+
+            throw new GroupInfoException(ExceptionMessage.GROUP_INFO_NOT_FOUND);
+        }
+
+        // 유저속한 그룹에서 그룹 아이디만 추출
+        List<Long> groupInfoIdList = groupInfoList.stream()
+                .map(GroupInfoUserGroupResponse::getId)
+                .collect(Collectors.toList());
+
+        // Map<GROUP_INFO_ID, HouseworkTodoCount> 각 그룹의 HouseworkTodo 가져오기
+        Map<Long, HouseworkTodoCount> houseworkTodoCountMap = houseworkTodoRepository.findHouseworkTodoCountByGroupInfoIdList(groupInfoIdList).stream()
+                .collect(Collectors.toMap(HouseworkTodoCount::getId, hwTodo -> hwTodo));
+
+        return groupInfoList.stream()
+                .map(groupInfo -> {
+                    if (houseworkTodoCountMap.containsKey(groupInfo.getId())) {
+                        List<HouseworkTodoStatus> statusList = houseworkTodoCountMap.get(groupInfo.getId()).getStatus();
+                        int remainTodoListCnt = (int) statusList.stream()
+                                .filter(status -> status == HouseworkTodoStatus.HOUSEWORK_TODO_INCOMPLETE)
+                                .count();
+
+                        return GroupInfoUserGroupServiceResponse.builder()
+                                .id(groupInfo.getId())
+                                .name(groupInfo.getName())
+                                .groupMembers(
+                                        groupInfo.getGroupMembers()
+                                )
+                                .remainTodoListCnt(remainTodoListCnt)
+                                .progressPercent(Math.round((float) (100 * (statusList.size() - remainTodoListCnt)) / statusList.size()))
+                                .build();
+                    } else {
+                        return GroupInfoUserGroupServiceResponse.builder()
+                                .id(groupInfo.getId())
+                                .name(groupInfo.getName())
+                                .groupMembers(
+                                        groupInfo.getGroupMembers()
+                                )
+                                .remainTodoListCnt(0)
+                                .progressPercent(0)
+                                .build();
+                    }
+                })
+                .collect(Collectors.toList());
+    }
+}

--- a/heachi-core/housework-api/src/main/java/com/heachi/housework/api/service/group/info/GroupInfoService.java
+++ b/heachi-core/housework-api/src/main/java/com/heachi/housework/api/service/group/info/GroupInfoService.java
@@ -87,6 +87,7 @@ public class GroupInfoService {
                     }
                 })
                 .collect(Collectors.toList());
+    }
 
     @Transactional
     public void createGroupInfo(GroupInfoCreateServiceRequest request) {

--- a/heachi-core/housework-api/src/main/java/com/heachi/housework/api/service/group/info/response/GroupInfoUserGroupServiceResponse.java
+++ b/heachi-core/housework-api/src/main/java/com/heachi/housework/api/service/group/info/response/GroupInfoUserGroupServiceResponse.java
@@ -1,0 +1,28 @@
+package com.heachi.housework.api.service.group.info.response;
+
+import com.heachi.mysql.define.group.info.repository.response.GroupInfoGroupMember;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.List;
+
+@Getter
+@ToString
+public class GroupInfoUserGroupServiceResponse {
+    private Long id;                                    // 그룹 아이디
+    private String name;                                // 그룹 이름
+    private List<GroupInfoGroupMember> groupMembers;    // 그룹 멤버
+    private int remainTodoListCnt;                      // 남은 집안일 개수
+    private int progressPercent;                        // 진행률 (소수점 첫째자리에서 반올림해서 정수로 표현)
+
+    @Builder
+    private GroupInfoUserGroupServiceResponse(Long id, String name, List<GroupInfoGroupMember> groupMembers,
+                                       int remainTodoListCnt, int progressPercent) {
+        this.id = id;
+        this.name = name;
+        this.groupMembers = groupMembers;
+        this.remainTodoListCnt = remainTodoListCnt;
+        this.progressPercent = progressPercent;
+    }
+}

--- a/heachi-core/housework-api/src/main/java/com/heachi/housework/api/service/housework/info/HouseworkInfoService.java
+++ b/heachi-core/housework-api/src/main/java/com/heachi/housework/api/service/housework/info/HouseworkInfoService.java
@@ -55,9 +55,9 @@ public class HouseworkInfoService {
 
             // GROUP_INFO 조회
             GroupInfo groupInfo = groupInfoRepository.findById(request.getGroupId()).orElseThrow(() -> {
-                log.warn(">>>> GroupInfo Not Found : {}", ExceptionMessage.GROUP_NOT_FOUND.getText());
+                log.warn(">>>> GroupInfo Not Found : {}", ExceptionMessage.GROUP_INFO_NOT_FOUND.getText());
 
-                throw new GroupInfoException(ExceptionMessage.GROUP_NOT_FOUND);
+                throw new GroupInfoException(ExceptionMessage.GROUP_INFO_NOT_FOUND);
             });
 
             // 담당자 지정 - HOUSEWORK_MEMBER 생성

--- a/heachi-core/housework-api/src/main/java/com/heachi/housework/api/service/housework/todo/TodoService.java
+++ b/heachi-core/housework-api/src/main/java/com/heachi/housework/api/service/housework/todo/TodoService.java
@@ -36,6 +36,7 @@ public class TodoService {
     private final HouseworkTodoRepository houseworkTodoRepository;
     private final HouseworkInfoRepository houseworkInfoRepository;
 
+    @Transactional
     public TodoList cachedSelectTodo(TodoSelectRequest request) {
 
         return CachingStrategy.cachingIfEmpty(request,

--- a/heachi-core/housework-api/src/test/java/com/heachi/housework/TestConfig.java
+++ b/heachi-core/housework-api/src/test/java/com/heachi/housework/TestConfig.java
@@ -60,7 +60,7 @@ public class TestConfig {
                 .build();
     }
 
-    public static User generateUser(String email, String phoneNumber) {
+    public static User generateCustomUser(String email, String phoneNumber) {
 
         return User.builder()
                 .platformId("123456")
@@ -103,14 +103,43 @@ public class TestConfig {
                 .build();
     }
 
-    public static HouseworkInfo generateHouseworkInfo(GroupInfo groupInfo, HouseworkCategory category) {
+    public static HouseworkCategory generateCustomHouseworkCategory(String name) {
+
+        return HouseworkCategory.builder()
+                .name(name)
+                .build();
+    }
+
+    public static HouseworkInfo generateHouseworkInfo(HouseworkCategory category) {
 
         return HouseworkInfo.builder()
                 .houseworkCategory(category)
-                .groupInfo(groupInfo)
                 .title("빨래")
                 .detail("빨래 돌리기")
                 .type(HouseworkPeriodType.HOUSEWORK_PERIOD_EVERYDAY)
+                .endTime(LocalTime.of(18,0))
+                .build();
+    }
+
+    public static HouseworkInfo generateHouseworkInfo(GroupInfo groupInfo, HouseworkCategory category) {
+
+        return HouseworkInfo.builder()
+                .groupInfo(groupInfo)
+                .houseworkCategory(category)
+                .title("빨래")
+                .detail("빨래 돌리기")
+                .type(HouseworkPeriodType.HOUSEWORK_PERIOD_EVERYDAY)
+                .endTime(LocalTime.of(18,0))
+                .build();
+    }
+
+    public static HouseworkInfo generateCustomHouseworkInfo(HouseworkCategory category, String title, HouseworkPeriodType type) {
+
+        return HouseworkInfo.builder()
+                .houseworkCategory(category)
+                .title(title)
+                .detail("빨래 돌리기")
+                .type(type)
                 .endTime(LocalTime.of(18,0))
                 .build();
     }

--- a/heachi-core/housework-api/src/test/java/com/heachi/housework/api/service/group/info/GroupInfoServiceTest.java
+++ b/heachi-core/housework-api/src/test/java/com/heachi/housework/api/service/group/info/GroupInfoServiceTest.java
@@ -1,0 +1,99 @@
+package com.heachi.housework.api.service.group.info;
+
+import com.heachi.housework.TestConfig;
+import com.heachi.housework.api.service.group.info.response.GroupInfoUserGroupServiceResponse;
+import com.heachi.mysql.define.group.info.GroupInfo;
+import com.heachi.mysql.define.group.info.repository.GroupInfoRepository;
+import com.heachi.mysql.define.group.member.GroupMember;
+import com.heachi.mysql.define.group.member.repository.GroupMemberRepository;
+import com.heachi.mysql.define.housework.category.HouseworkCategory;
+import com.heachi.mysql.define.housework.category.repository.HouseworkCategoryRepository;
+import com.heachi.mysql.define.housework.info.HouseworkInfo;
+import com.heachi.mysql.define.housework.info.repository.HouseworkInfoRepository;
+import com.heachi.mysql.define.housework.member.HouseworkMember;
+import com.heachi.mysql.define.housework.member.repository.HouseworkMemberRepository;
+import com.heachi.mysql.define.housework.todo.HouseworkTodo;
+import com.heachi.mysql.define.housework.todo.repository.HouseworkTodoRepository;
+import com.heachi.mysql.define.user.User;
+import com.heachi.mysql.define.user.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class GroupInfoServiceTest extends TestConfig {
+
+    @Autowired private GroupMemberRepository groupMemberRepository;
+    @Autowired private UserRepository userRepository;
+    @Autowired private GroupInfoRepository groupInfoRepository;
+    @Autowired private HouseworkCategoryRepository houseworkCategoryRepository;
+    @Autowired private HouseworkInfoRepository houseworkInfoRepository;
+    @Autowired private HouseworkTodoRepository houseworkTodoRepository;
+    @Autowired private HouseworkMemberRepository houseworkMemberRepository;
+
+    @Autowired private GroupInfoService groupInfoService;
+
+    @AfterEach
+    void tearDown() {
+        houseworkTodoRepository.deleteAllInBatch();
+        houseworkMemberRepository.deleteAllInBatch();
+        houseworkInfoRepository.deleteAllInBatch();
+        houseworkCategoryRepository.deleteAllInBatch();
+        groupMemberRepository.deleteAllInBatch();
+        groupInfoRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
+    }
+
+    @Test
+    @DisplayName("유저의 email을 통해 유저가 속한 그룹과 각 그룹의 멤버, 해당 날짜의 그룹별 집안일 진행상황을 나타낸다.")
+    void userGroupInfoList() {
+        // given
+        User user = userRepository.save(generateUser());
+        User user2 = userRepository.save(generateCustomUser("ghdcksgml1@naver.com", "010-1111-1111"));
+        User user3 = userRepository.save(generateCustomUser("ghdcksgml2@naver.com", "010-2222-2222"));
+        GroupInfo groupInfo = groupInfoRepository.save(generateGroupInfo(user));
+        GroupInfo groupInfo2 = groupInfoRepository.save(generateGroupInfo(user2));
+        GroupInfo groupInfo3 = groupInfoRepository.save(generateGroupInfo(user3));
+        GroupMember groupMember = groupMemberRepository.save(generateGroupMember(user, groupInfo));
+        groupMemberRepository.save(generateGroupMember(user2, groupInfo));
+        groupMemberRepository.save(generateGroupMember(user3, groupInfo));
+        groupMemberRepository.save(generateGroupMember(user, groupInfo3));
+        groupMemberRepository.save(generateGroupMember(user3, groupInfo2));
+
+        HouseworkCategory houseworkCategory = houseworkCategoryRepository.save(generateHouseworkCategory());
+        HouseworkInfo houseworkInfo = houseworkInfoRepository.save(generateHouseworkInfo(houseworkCategory));
+        HouseworkInfo houseworkInfo2 = houseworkInfoRepository.save(generateHouseworkInfo(houseworkCategory));
+        HouseworkInfo houseworkInfo3 = houseworkInfoRepository.save(generateHouseworkInfo(houseworkCategory));
+
+        HouseworkMember houseworkMember = houseworkMemberRepository.save(generateHouseworkMember(groupMember, houseworkInfo));
+        HouseworkInfo findHouseworkInfo = houseworkInfoRepository.findHouseworkInfoByIdJoinFetchHouseworkMembers(houseworkInfo.getId()).get();
+        HouseworkInfo findHouseworkInfo2 = houseworkInfoRepository.findHouseworkInfoByIdJoinFetchHouseworkMembers(houseworkInfo2.getId()).get();
+        HouseworkInfo findHouseworkInfo3 = houseworkInfoRepository.findHouseworkInfoByIdJoinFetchHouseworkMembers(houseworkInfo3.getId()).get();
+
+        HouseworkTodo houseworkTodo = houseworkTodoRepository.save(generateHouseworkTodo(findHouseworkInfo, groupInfo, LocalDate.now()));
+        HouseworkTodo houseworkTodo2 = houseworkTodoRepository.save(generateHouseworkTodo(findHouseworkInfo2, groupInfo2, LocalDate.now()));
+        HouseworkTodo houseworkTodo3 = houseworkTodoRepository.save(generateHouseworkTodo(findHouseworkInfo3, groupInfo3, LocalDate.now()));
+
+        // when
+        List<GroupInfoUserGroupServiceResponse> groupServiceResponses = groupInfoService.userGroupInfoList(user.getEmail());
+        groupServiceResponses.forEach(System.out::println);
+
+        // then
+        assertThat(groupServiceResponses.get(0).getGroupMembers().size()).isEqualTo(3);
+        assertThat(groupServiceResponses.get(0).getRemainTodoListCnt()).isEqualTo(1);
+        assertThat(groupServiceResponses.get(0).getProgressPercent()).isEqualTo(0);
+
+        assertThat(groupServiceResponses.get(1).getGroupMembers().size()).isEqualTo(1);
+        assertThat(groupServiceResponses.get(1).getRemainTodoListCnt()).isEqualTo(1);
+        assertThat(groupServiceResponses.get(1).getProgressPercent()).isEqualTo(0);
+    }
+
+}

--- a/heachi-core/housework-api/src/test/java/com/heachi/housework/api/service/housework/todo/TodoServiceTest.java
+++ b/heachi-core/housework-api/src/test/java/com/heachi/housework/api/service/housework/todo/TodoServiceTest.java
@@ -151,7 +151,7 @@ class TodoServiceTest extends TestConfig {
     void test4() {
         // given
         User user = userRepository.save(generateUser());
-        User user2 = userRepository.save(generateUser("kmm@kakao.com", "010-1111-1111"));
+        User user2 = userRepository.save(generateCustomUser("kmm@kakao.com", "010-1111-1111"));
         GroupInfo groupInfo = groupInfoRepository.save(generateGroupInfo(user));
         GroupMember groupMember = groupMemberRepository.save(generateGroupMember(user, groupInfo));
         GroupMember groupMember2 = groupMemberRepository.save(generateGroupMember(user2, groupInfo));

--- a/heachi-domain-mysql/src/main/generated/com/heachi/mysql/define/group/info/QGroupInfo.java
+++ b/heachi-domain-mysql/src/main/generated/com/heachi/mysql/define/group/info/QGroupInfo.java
@@ -33,6 +33,8 @@ public class QGroupInfo extends EntityPathBase<GroupInfo> {
 
     public final StringPath gradient = createString("gradient");
 
+    public final ListPath<com.heachi.mysql.define.group.member.GroupMember, com.heachi.mysql.define.group.member.QGroupMember> groupMembers = this.<com.heachi.mysql.define.group.member.GroupMember, com.heachi.mysql.define.group.member.QGroupMember>createList("groupMembers", com.heachi.mysql.define.group.member.GroupMember.class, com.heachi.mysql.define.group.member.QGroupMember.class, PathInits.DIRECT2);
+
     public final ListPath<com.heachi.mysql.define.housework.todo.HouseworkTodo, com.heachi.mysql.define.housework.todo.QHouseworkTodo> houseworkTodoList = this.<com.heachi.mysql.define.housework.todo.HouseworkTodo, com.heachi.mysql.define.housework.todo.QHouseworkTodo>createList("houseworkTodoList", com.heachi.mysql.define.housework.todo.HouseworkTodo.class, com.heachi.mysql.define.housework.todo.QHouseworkTodo.class, PathInits.DIRECT2);
 
     public final NumberPath<Long> id = createNumber("id", Long.class);

--- a/heachi-domain-mysql/src/main/java/com/heachi/mysql/config/querydsl/QueryDslConfig.java
+++ b/heachi-domain-mysql/src/main/java/com/heachi/mysql/config/querydsl/QueryDslConfig.java
@@ -1,5 +1,6 @@
 package com.heachi.mysql.config.querydsl;
 
+import com.querydsl.jpa.JPQLTemplates;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
@@ -14,6 +15,6 @@ public class QueryDslConfig {
 
     @Bean
     public JPAQueryFactory jpaQueryFactory() {
-        return new JPAQueryFactory(em);
+        return new JPAQueryFactory(JPQLTemplates.DEFAULT, em);
     }
 }

--- a/heachi-domain-mysql/src/main/java/com/heachi/mysql/define/group/info/GroupInfo.java
+++ b/heachi-domain-mysql/src/main/java/com/heachi/mysql/define/group/info/GroupInfo.java
@@ -1,6 +1,7 @@
 package com.heachi.mysql.define.group.info;
 
 import com.heachi.mysql.define.BaseEntity;
+import com.heachi.mysql.define.group.member.GroupMember;
 import com.heachi.mysql.define.housework.todo.HouseworkTodo;
 import com.heachi.mysql.define.user.User;
 import jakarta.persistence.*;
@@ -24,6 +25,9 @@ public class GroupInfo extends BaseEntity {
 
     @OneToMany(mappedBy = "groupInfo")   // 집안일 리스트
     private List<HouseworkTodo> houseworkTodoList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "groupInfo")   // 그룹 멤버
+    private List<GroupMember> groupMembers = new ArrayList<>();
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "USER_ID", nullable = false)

--- a/heachi-domain-mysql/src/main/java/com/heachi/mysql/define/group/info/repository/GroupInfoRepository.java
+++ b/heachi-domain-mysql/src/main/java/com/heachi/mysql/define/group/info/repository/GroupInfoRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface GroupInfoRepository extends JpaRepository<GroupInfo, Long> {
+public interface GroupInfoRepository extends JpaRepository<GroupInfo, Long>, GroupInfoRepositoryCustom {
     // 그룹장 User 정보로 조회
     Optional<GroupInfo> findByUser(User user);
 }

--- a/heachi-domain-mysql/src/main/java/com/heachi/mysql/define/group/info/repository/GroupInfoRepositoryCustom.java
+++ b/heachi-domain-mysql/src/main/java/com/heachi/mysql/define/group/info/repository/GroupInfoRepositoryCustom.java
@@ -1,0 +1,12 @@
+package com.heachi.mysql.define.group.info.repository;
+
+import com.heachi.mysql.define.group.info.GroupInfo;
+import com.heachi.mysql.define.group.info.repository.response.GroupInfoUserGroupResponse;
+
+import java.util.List;
+
+public interface GroupInfoRepositoryCustom {
+
+    // 유저 이메일을 통해 해당 유저가 속한 그룹의 정보들을 가져와 주는 쿼리
+    public List<GroupInfoUserGroupResponse> findGroupInfoUserGroupResponseListByUserEmail(String email);
+}

--- a/heachi-domain-mysql/src/main/java/com/heachi/mysql/define/group/info/repository/GroupInfoRepositoryImpl.java
+++ b/heachi-domain-mysql/src/main/java/com/heachi/mysql/define/group/info/repository/GroupInfoRepositoryImpl.java
@@ -1,0 +1,60 @@
+package com.heachi.mysql.define.group.info.repository;
+
+import com.heachi.mysql.define.group.info.GroupInfo;
+import com.heachi.mysql.define.group.info.repository.response.GroupInfoGroupMember;
+import com.heachi.mysql.define.group.info.repository.response.GroupInfoUserGroupResponse;
+import com.heachi.mysql.define.group.member.constant.GroupMemberStatus;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.heachi.mysql.define.group.info.QGroupInfo.groupInfo;
+import static com.heachi.mysql.define.group.member.QGroupMember.groupMember;
+import static com.heachi.mysql.define.user.QUser.user;
+import static com.querydsl.core.group.GroupBy.groupBy;
+import static com.querydsl.core.group.GroupBy.list;
+
+@Component
+@RequiredArgsConstructor
+public class GroupInfoRepositoryImpl implements GroupInfoRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<GroupInfoUserGroupResponse> findGroupInfoUserGroupResponseListByUserEmail(String email) {
+
+        List<GroupInfo> groupInfoList = queryFactory
+                .selectFrom(groupInfo)
+                .leftJoin(groupInfo.groupMembers, groupMember).fetchJoin()
+                .innerJoin(groupMember.user, user).fetchJoin()
+                .where(groupInfo.id.in(
+                        JPAExpressions // 유저가 속해있는 그룹 아이디 가져오기
+                                .select(groupMember.groupInfo.id)
+                                .from(groupMember)
+                                .innerJoin(groupMember.user, user)
+                                .where(user.email.eq(email)
+                                        .and(groupMember.status.eq(GroupMemberStatus.ACCEPT)))
+                ))
+                .fetch();
+
+        return groupInfoList.stream()
+                .map(groupInfo -> GroupInfoUserGroupResponse.builder()
+                        .id(groupInfo.getId())
+                        .name(groupInfo.getName())
+                        .groupMembers(
+                                groupInfo.getGroupMembers().stream()
+                                        .map(groupMember -> GroupInfoGroupMember.builder()
+                                                .name(groupMember.getUser().getName())
+                                                .profileImageUrl(groupMember.getUser().getProfileImageUrl())
+                                                .build())
+                                        .collect(Collectors.toList()))
+                        .build())
+                .collect(Collectors.toList());
+    }
+}

--- a/heachi-domain-mysql/src/main/java/com/heachi/mysql/define/group/info/repository/GroupInfoRepositoryImpl.java
+++ b/heachi-domain-mysql/src/main/java/com/heachi/mysql/define/group/info/repository/GroupInfoRepositoryImpl.java
@@ -49,6 +49,8 @@ public class GroupInfoRepositoryImpl implements GroupInfoRepositoryCustom {
                         .name(groupInfo.getName())
                         .groupMembers(
                                 groupInfo.getGroupMembers().stream()
+                                        // 현재 그룹 멤버만
+                                        .filter(groupMember -> groupMember.getStatus() == GroupMemberStatus.ACCEPT)
                                         .map(groupMember -> GroupInfoGroupMember.builder()
                                                 .name(groupMember.getUser().getName())
                                                 .profileImageUrl(groupMember.getUser().getProfileImageUrl())

--- a/heachi-domain-mysql/src/main/java/com/heachi/mysql/define/group/info/repository/response/GroupInfoGroupMember.java
+++ b/heachi-domain-mysql/src/main/java/com/heachi/mysql/define/group/info/repository/response/GroupInfoGroupMember.java
@@ -1,0 +1,18 @@
+package com.heachi.mysql.define.group.info.repository.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class GroupInfoGroupMember {
+    private String name;            // 멤버 이름
+    private String profileImageUrl; // 멤버 프로필 사진
+
+    @Builder
+    private GroupInfoGroupMember(String name, String profileImageUrl) {
+        this.name = name;
+        this.profileImageUrl = profileImageUrl;
+    }
+}

--- a/heachi-domain-mysql/src/main/java/com/heachi/mysql/define/group/info/repository/response/GroupInfoUserGroupResponse.java
+++ b/heachi-domain-mysql/src/main/java/com/heachi/mysql/define/group/info/repository/response/GroupInfoUserGroupResponse.java
@@ -1,0 +1,22 @@
+package com.heachi.mysql.define.group.info.repository.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.List;
+
+@Getter
+@ToString
+public class GroupInfoUserGroupResponse {
+    private Long id;                                    // 그룹 아이디
+    private String name;                                // 그룹 이름
+    private List<GroupInfoGroupMember> groupMembers;    // 그룹 멤버
+
+    @Builder
+    private GroupInfoUserGroupResponse(Long id, String name, List<GroupInfoGroupMember> groupMembers) {
+        this.id = id;
+        this.name = name;
+        this.groupMembers = groupMembers;
+    }
+}

--- a/heachi-domain-mysql/src/main/java/com/heachi/mysql/define/housework/todo/repository/HouseworkTodoRepository.java
+++ b/heachi-domain-mysql/src/main/java/com/heachi/mysql/define/housework/todo/repository/HouseworkTodoRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.repository.query.Param;
 import java.time.LocalDate;
 import java.util.List;
 
-public interface HouseworkTodoRepository extends JpaRepository<HouseworkTodo, Long> {
+public interface HouseworkTodoRepository extends JpaRepository<HouseworkTodo, Long>, HouseworkTodoRepositoryCustom {
 
     @Query("select ht from HOUSEWORK_TODO ht where ht.groupInfo.id = :groupId and ht.date = :date")
     public List<HouseworkTodo> findByGroupInfoAndDate(@Param(value = "groupId") Long groupId,

--- a/heachi-domain-mysql/src/main/java/com/heachi/mysql/define/housework/todo/repository/HouseworkTodoRepositoryCustom.java
+++ b/heachi-domain-mysql/src/main/java/com/heachi/mysql/define/housework/todo/repository/HouseworkTodoRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.heachi.mysql.define.housework.todo.repository;
+
+import com.heachi.mysql.define.housework.todo.repository.response.HouseworkTodoCount;
+
+import java.util.List;
+
+public interface HouseworkTodoRepositoryCustom {
+
+    // groupInfoId 리스트를 받아 해당 그룹들의 오늘 날짜의 HouseworkTodo의 개수를 셀 수 있는 DTO를 반환하는 쿼리
+    public List<HouseworkTodoCount> findHouseworkTodoCountByGroupInfoIdList(List<Long> groupInfoIdList);
+}

--- a/heachi-domain-mysql/src/main/java/com/heachi/mysql/define/housework/todo/repository/HouseworkTodoRepositoryImpl.java
+++ b/heachi-domain-mysql/src/main/java/com/heachi/mysql/define/housework/todo/repository/HouseworkTodoRepositoryImpl.java
@@ -1,0 +1,40 @@
+package com.heachi.mysql.define.housework.todo.repository;
+
+import com.heachi.mysql.define.housework.todo.repository.response.HouseworkTodoCount;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static com.heachi.mysql.define.group.info.QGroupInfo.groupInfo;
+import static com.heachi.mysql.define.housework.todo.QHouseworkTodo.houseworkTodo;
+import static com.querydsl.core.group.GroupBy.groupBy;
+import static com.querydsl.core.group.GroupBy.list;
+
+@Component
+@RequiredArgsConstructor
+public class HouseworkTodoRepositoryImpl implements HouseworkTodoRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<HouseworkTodoCount> findHouseworkTodoCountByGroupInfoIdList(List<Long> groupInfoIdList) {
+
+        return queryFactory
+                .from(houseworkTodo)
+                .where(houseworkTodo.groupInfo.id.in(groupInfoIdList)
+                        .and(houseworkTodo.date.eq(LocalDate.now()))) // 오늘
+                .transform(
+                        groupBy(houseworkTodo.groupInfo.id).list(
+                                Projections.fields(
+                                        HouseworkTodoCount.class,
+                                        houseworkTodo.groupInfo.id.as("id"),
+                                        list(houseworkTodo.status).as("status")
+                                )
+                        )
+                );
+    }
+}

--- a/heachi-domain-mysql/src/main/java/com/heachi/mysql/define/housework/todo/repository/response/HouseworkTodoCount.java
+++ b/heachi-domain-mysql/src/main/java/com/heachi/mysql/define/housework/todo/repository/response/HouseworkTodoCount.java
@@ -1,0 +1,14 @@
+package com.heachi.mysql.define.housework.todo.repository.response;
+
+import com.heachi.mysql.define.housework.todo.constant.HouseworkTodoStatus;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.List;
+
+@Getter
+@ToString
+public class HouseworkTodoCount {
+    private Long id;                            // groupInfo Id
+    private List<HouseworkTodoStatus> status;   // HouseworkTodo의 상태
+}

--- a/heachi-domain-mysql/src/test/java/com/heachi/mysql/TestConfig.java
+++ b/heachi-domain-mysql/src/test/java/com/heachi/mysql/TestConfig.java
@@ -44,6 +44,20 @@ public class TestConfig {
                 .build();
     }
 
+    public static User generateCustomUser(String email, String phoneNumber) {
+
+        return User.builder()
+                .platformId("123456")
+                .platformType(UserPlatformType.KAKAO)
+                .role(UserRole.USER)
+                .name("kms")
+                .email(email)
+                .phoneNumber(phoneNumber)
+                .profileImageUrl("https://google.com")
+                .pushAlarmYn(true)
+                .build();
+    }
+
     public static GroupInfo generateGroupInfo(User user) {
 
         return GroupInfo.builder()
@@ -73,6 +87,13 @@ public class TestConfig {
                 .build();
     }
 
+    public static HouseworkCategory generateCustomHouseworkCategory(String name) {
+
+        return HouseworkCategory.builder()
+                .name(name)
+                .build();
+    }
+
     public static HouseworkInfo generateHouseworkInfo(HouseworkCategory category) {
 
         return HouseworkInfo.builder()
@@ -80,6 +101,17 @@ public class TestConfig {
                 .title("빨래")
                 .detail("빨래 돌리기")
                 .type(HouseworkPeriodType.HOUSEWORK_PERIOD_EVERYDAY)
+                .endTime(LocalTime.of(18,0))
+                .build();
+    }
+
+    public static HouseworkInfo generateCustomHouseworkInfo(HouseworkCategory category, String title, HouseworkPeriodType type) {
+
+        return HouseworkInfo.builder()
+                .houseworkCategory(category)
+                .title(title)
+                .detail("빨래 돌리기")
+                .type(type)
                 .endTime(LocalTime.of(18,0))
                 .build();
     }

--- a/heachi-support/common/src/main/java/com/heachi/admin/common/exception/ExceptionMessage.java
+++ b/heachi-support/common/src/main/java/com/heachi/admin/common/exception/ExceptionMessage.java
@@ -37,8 +37,8 @@ public enum ExceptionMessage {
     AUTH_NOT_FOUND("계정 정보를 찾을 수 없습니다."),
     AUTH_DELETE_FAIL("계정 삭제에 실패했습니다."),
 
-    // GroupException
-    GROUP_NOT_FOUND("그룹을 찾지 못했습니다."),
+    // GroupInfoException
+    GROUP_INFO_NOT_FOUND("그룹을 찾지 못했습니다."),
 
     // GroupMemberException
     GROUP_MEMBER_NOT_FOUND("그룹 멤버를 찾지 못했습니다."),


### PR DESCRIPTION
## 작업 내용

- [x] 유저 이메일을 통해 유저의 모든 그룹을 알아내는 쿼리
- [x] Authorization 헤더 전송을 통한 유저가 속한 그룹을 모두 가져오는 API
### 테스트
- [x] groupInfoId 리스트를 받아 해당 그룹들의 오늘 날짜의 HouseworkTodo의 개수를 셀 수 있는 DTO를 반환해준다.
- [x] 유저 이메일을 통해 해당 유저가 속한 그룹의 정보들을 가져와 주는 쿼리
- [x] 유저의 email을 통해 유저가 속한 그룹과 각 그룹의 멤버, 해당 날짜의 그룹별 집안일 진행상황을 나타낸다.

<br/><br/>

## 관련 이슈

#75 