### PR TITLE
Feat(#94) group member request handling

### DIFF
--- a/heachi-core/housework-api/src/main/java/com/heachi/housework/api/controller/group/info/GroupInfoController.java
+++ b/heachi-core/housework-api/src/main/java/com/heachi/housework/api/controller/group/info/GroupInfoController.java
@@ -2,6 +2,7 @@ package com.heachi.housework.api.controller.group.info;
 
 import com.heachi.admin.common.response.JsonResult;
 import com.heachi.external.clients.auth.response.UserInfoResponse;
+import com.heachi.housework.api.controller.group.info.request.GroupInfoRegisterRequest;
 import com.heachi.housework.api.service.auth.AuthExternalService;
 import com.heachi.housework.api.service.group.info.GroupInfoService;
 import lombok.RequiredArgsConstructor;
@@ -61,5 +62,16 @@ public class GroupInfoController {
         groupInfoService.joinGroupInfo(userInfo.getEmail(), joinCode);
 
         return JsonResult.successOf("성공적으로 그룹에 가입했습니다.");
+    }
+
+    // 그룹 가입 요청 처리
+    @PostMapping("/register")
+    public JsonResult<?> joinGroupRequestHandler(@RequestHeader(name = "Authorization") String authorization,
+                                                 @Valid @RequestBody GroupInfoRegisterRequest request) {
+        // Auth 서버에서 사용자 인증
+        UserInfoResponse userInfo = authExternalService.userAuthenticate(authorization);
+        groupInfoService.joinRequestHandler(userInfo.getEmail(), request);
+
+        return JsonResult.successOf("그룹 가입 요청을 성공적으로 수행했습니다.");
     }
 }

--- a/heachi-core/housework-api/src/main/java/com/heachi/housework/api/controller/group/info/request/GroupInfoRegisterRequest.java
+++ b/heachi-core/housework-api/src/main/java/com/heachi/housework/api/controller/group/info/request/GroupInfoRegisterRequest.java
@@ -1,0 +1,18 @@
+package com.heachi.housework.api.controller.group.info.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GroupInfoRegisterRequest {
+    private Long groupMemberId;
+    private Long groupId;
+    @NotEmpty
+    private boolean status;
+}

--- a/heachi-core/housework-api/src/main/java/com/heachi/housework/api/controller/group/info/request/GroupInfoRegisterRequest.java
+++ b/heachi-core/housework-api/src/main/java/com/heachi/housework/api/controller/group/info/request/GroupInfoRegisterRequest.java
@@ -2,17 +2,19 @@ package com.heachi.housework.api.controller.group.info.request;
 
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
 public class GroupInfoRegisterRequest {
     private Long groupMemberId;
     private Long groupId;
     @NotEmpty
     private boolean status;
+
+    @Builder
+    private GroupInfoRegisterRequest(Long groupMemberId, Long groupId, boolean status) {
+        this.groupMemberId = groupMemberId;
+        this.groupId = groupId;
+        this.status = status;
+    }
 }

--- a/heachi-core/housework-api/src/main/java/com/heachi/housework/api/controller/group/info/request/GroupInfoRegisterRequest.java
+++ b/heachi-core/housework-api/src/main/java/com/heachi/housework/api/controller/group/info/request/GroupInfoRegisterRequest.java
@@ -9,10 +9,10 @@ public class GroupInfoRegisterRequest {
     private Long groupMemberId;
     private Long groupId;
     @NotEmpty
-    private boolean status;
+    private GroupInfoRegisterRequestStatusEnum status;
 
     @Builder
-    private GroupInfoRegisterRequest(Long groupMemberId, Long groupId, boolean status) {
+    private GroupInfoRegisterRequest(Long groupMemberId, Long groupId, GroupInfoRegisterRequestStatusEnum status) {
         this.groupMemberId = groupMemberId;
         this.groupId = groupId;
         this.status = status;

--- a/heachi-core/housework-api/src/main/java/com/heachi/housework/api/controller/group/info/request/GroupInfoRegisterRequestStatusEnum.java
+++ b/heachi-core/housework-api/src/main/java/com/heachi/housework/api/controller/group/info/request/GroupInfoRegisterRequestStatusEnum.java
@@ -1,0 +1,6 @@
+package com.heachi.housework.api.controller.group.info.request;
+
+public enum GroupInfoRegisterRequestStatusEnum {
+    ACCEPT,
+    REFUSE
+}

--- a/heachi-core/housework-api/src/main/java/com/heachi/housework/api/controller/housework/info/HouseworkInfoController.java
+++ b/heachi-core/housework-api/src/main/java/com/heachi/housework/api/controller/housework/info/HouseworkInfoController.java
@@ -6,6 +6,7 @@ import com.heachi.housework.api.controller.housework.info.request.HouseworkInfoC
 import com.heachi.housework.api.service.auth.AuthExternalService;
 import com.heachi.housework.api.service.housework.info.HouseworkInfoService;
 import com.heachi.housework.api.service.housework.info.request.HouseworkInfoCreateServiceRequest;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
@@ -21,7 +22,7 @@ public class HouseworkInfoController {
     @PostMapping("/{groupId}")
     public JsonResult<?> createHouseworkInfo(@RequestHeader(name = "Authorization") String authorization,
                                              @PathVariable(name = "groupId") Long groupId,
-                                             @RequestBody HouseworkInfoCreateRequest request
+                                             @Valid @RequestBody HouseworkInfoCreateRequest request
     ) {
         // Auth 서버로 요청자 인증 요청 - 해당 그룹원인지 판별하고 상태가 ACCEPT인지 확인
         try {

--- a/heachi-core/housework-api/src/main/java/com/heachi/housework/api/service/group/info/GroupInfoService.java
+++ b/heachi-core/housework-api/src/main/java/com/heachi/housework/api/service/group/info/GroupInfoService.java
@@ -4,6 +4,7 @@ import com.heachi.admin.common.exception.ExceptionMessage;
 import com.heachi.admin.common.exception.group.info.GroupInfoException;
 import com.heachi.admin.common.exception.group.member.GroupMemberException;
 import com.heachi.housework.api.controller.group.info.request.GroupInfoRegisterRequest;
+import com.heachi.housework.api.controller.group.info.request.GroupInfoRegisterRequestStatusEnum;
 import com.heachi.housework.api.service.group.info.response.GroupInfoUserGroupServiceResponse;
 import com.heachi.mysql.define.group.info.repository.GroupInfoRepository;
 import com.heachi.mysql.define.group.info.repository.response.GroupInfoUserGroupResponse;
@@ -193,9 +194,10 @@ public class GroupInfoService {
         }
 
         // status에 따른 그룹 가입 요청 핸들링
-        GroupMemberStatus updateStatus = request.isStatus() ? GroupMemberStatus.ACCEPT : GroupMemberStatus.WITHDRAW;
-
-        // requestGroupMember update
-        requestGroupMember.updateStatus(updateStatus);
+        if (request.getStatus().equals(GroupInfoRegisterRequestStatusEnum.ACCEPT)) {
+            requestGroupMember.acceptJoin();
+        } else {
+            requestGroupMember.refuseJoin();
+        }
     }
 }

--- a/heachi-core/housework-api/src/main/java/com/heachi/housework/api/service/group/info/GroupInfoService.java
+++ b/heachi-core/housework-api/src/main/java/com/heachi/housework/api/service/group/info/GroupInfoService.java
@@ -164,36 +164,8 @@ public class GroupInfoService {
 
     @Transactional
     public void joinRequestHandler(String adminEmail, GroupInfoRegisterRequest request) {
-        // 그룹 정보 조회
-        GroupInfo groupInfo = groupInfoRepository.findById(request.getGroupId()).orElseThrow(() -> {
-            log.warn(">>>> 해당 groupId를 가진 그룹이 존재하지 않습니다 : [{}]", request.getGroupId());
-
-            throw new GroupInfoException(ExceptionMessage.GROUP_INFO_NOT_FOUND);
-        });
-
-        // 그룹 가입 요청자 조회
-        GroupMember requestGroupMember = groupMemberRepository.findByIdAndGroupInfo(request.getGroupMemberId(), groupInfo).orElseThrow(() -> {
-            log.warn(">>>> Group Member Not Found : [{}]", request.getGroupMemberId());
-
-            throw new GroupMemberException(ExceptionMessage.GROUP_MEMBER_NOT_FOUND);
-        });
-
-        // 그룹 가입 요청자 상태 확인: WAITING 상태가 아닐경우 예외처리
-        if (requestGroupMember.getStatus() != GroupMemberStatus.WAITING) {
-            log.warn(">>>> Group Member's Status Is Not WAITING : [{}]", requestGroupMember.getStatus());
-
-            throw new GroupMemberException(ExceptionMessage.GROUP_MEMBER_STATUS_NOT_WAITING);
-        }
-
-        // adminEmail로 User 정보 조회
-        User adminUser = userRepository.findByEmail(adminEmail).orElseThrow(() -> {
-            log.warn(">>>> USER NOT FOUND : [{}]", adminEmail);
-
-            throw new UserException(ExceptionMessage.USER_NOT_FOUND);
-        });
-
-        // User 정보와 GroupInfo 정보로 GROUP_MEMBER 조회
-        GroupMember adminGroupMember = groupMemberRepository.findByUserAndGroupInfo(adminUser, groupInfo).orElseThrow(() -> {
+        // 그룹장의 email과 GroupId로 GROUP_MEMBER 조회
+        GroupMember adminGroupMember = groupMemberRepository.findGroupMemberByUserEmailAndGroupInfoId(adminEmail, request.getGroupId()).orElseThrow(() -> {
             log.warn(">>>> 해당 그룹의 구성원이 아닙니다. : [{}]", adminEmail);
 
             throw new GroupMemberException(ExceptionMessage.GROUP_MEMBER_NOT_FOUND);
@@ -204,6 +176,20 @@ public class GroupInfoService {
             log.warn(">>>> 해당 그룹의 그룹장이 아닙니다. : [role: {}]", adminGroupMember.getRole());
 
             throw new GroupMemberException(ExceptionMessage.GROUP_MEMBER_ROLE_NOT_ADMIN);
+        }
+
+        // 그룹 가입 요청자 조회
+        GroupMember requestGroupMember = groupMemberRepository.findGroupMemberByGroupMemberIdAndGroupInfoId(request.getGroupMemberId(), request.getGroupId()).orElseThrow(() -> {
+            log.warn(">>>> Group Member Not Found : [{}]", request.getGroupMemberId());
+
+            throw new GroupMemberException(ExceptionMessage.GROUP_MEMBER_NOT_FOUND);
+        });
+
+        // 그룹 가입 요청자 상태 확인: WAITING 상태가 아닐경우 예외처리
+        if (requestGroupMember.getStatus() != GroupMemberStatus.WAITING) {
+            log.warn(">>>> Group Member's Status Is Not WAITING : [{}]", requestGroupMember.getStatus());
+
+            throw new GroupMemberException(ExceptionMessage.GROUP_MEMBER_STATUS_NOT_WAITING);
         }
 
         // status에 따른 그룹 가입 요청 핸들링

--- a/heachi-core/housework-api/src/main/java/com/heachi/housework/api/service/group/info/GroupInfoService.java
+++ b/heachi-core/housework-api/src/main/java/com/heachi/housework/api/service/group/info/GroupInfoService.java
@@ -207,7 +207,7 @@ public class GroupInfoService {
         }
 
         // status에 따른 그룹 가입 요청 핸들링
-        GroupMemberStatus updateStatus = request.isStatus() ? GroupMemberStatus.ACCEPT : GroupMemberStatus.WAITING;
+        GroupMemberStatus updateStatus = request.isStatus() ? GroupMemberStatus.ACCEPT : GroupMemberStatus.WITHDRAW;
 
         // requestGroupMember update
         requestGroupMember.updateStatus(updateStatus);

--- a/heachi-core/housework-api/src/test/java/com/heachi/housework/api/service/group/info/GroupInfoServiceTest.java
+++ b/heachi-core/housework-api/src/test/java/com/heachi/housework/api/service/group/info/GroupInfoServiceTest.java
@@ -1,6 +1,10 @@
 package com.heachi.housework.api.service.group.info;
 
+import com.heachi.admin.common.exception.ExceptionMessage;
+import com.heachi.admin.common.exception.group.info.GroupInfoException;
+import com.heachi.admin.common.exception.group.member.GroupMemberException;
 import com.heachi.housework.TestConfig;
+import com.heachi.housework.api.controller.group.info.request.GroupInfoRegisterRequest;
 import com.heachi.housework.api.service.group.info.response.GroupInfoUserGroupServiceResponse;
 import com.heachi.admin.common.exception.user.UserException;
 import com.heachi.housework.TestConfig;
@@ -21,6 +25,8 @@ import com.heachi.mysql.define.housework.todo.HouseworkTodo;
 import com.heachi.mysql.define.housework.todo.repository.HouseworkTodoRepository;
 
 import com.heachi.mysql.define.user.User;
+import com.heachi.mysql.define.user.constant.UserPlatformType;
+import com.heachi.mysql.define.user.constant.UserRole;
 import com.heachi.mysql.define.user.repository.UserRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
@@ -244,4 +250,188 @@ class GroupInfoServiceTest extends TestConfig {
         assertThat(findGroupMember.getStatus()).isEqualTo(GroupMemberStatus.WAITING);
         assertThat(findGroupMember.getRole()).isEqualTo(GroupMemberRole.GROUP_MEMBER);
     }
+
+    @Test
+    @DisplayName("그룹 가입 요청자의 상태가 WAITING이 아닐 경우 예외가 발생한다.")
+    void joinRequestGroupMemberStatusIsNotWAITING() {
+        // given
+        // Admin
+        User admin = userRepository.save(generateUser());
+        GroupInfo groupInfo = groupInfoRepository.save(generateGroupInfo(admin));
+
+        GroupMember adminMember = GroupMember.builder()
+                .groupInfo(groupInfo)
+                .role(GroupMemberRole.GROUP_ADMIN)
+                .status(GroupMemberStatus.ACCEPT)
+                .user(admin)
+                .build();
+        groupMemberRepository.save(adminMember);
+
+
+        // 그룹 가입 요청자
+        User requestUser =  userRepository.save(User.builder()
+                .platformId("11")
+                .platformType(UserPlatformType.KAKAO)
+                .role(UserRole.USER)
+                .name("test")
+                .email("test@test.com")
+                .phoneNumber("010-1233-0000")
+                .profileImageUrl("https://google.com")
+                .pushAlarmYn(true)
+                .build());
+        // WAITING 상태가 아닌 ACCEPT 상태
+        GroupMember requestAcceptMember = groupMemberRepository.save(generateGroupMember(requestUser, groupInfo));
+
+        GroupInfoRegisterRequest request = GroupInfoRegisterRequest.builder()
+                .groupMemberId(requestAcceptMember.getId())
+                .groupId(groupInfo.getId())
+                .status(true)
+                .build();
+
+        String adminEmail = "test@test.com";
+
+        // when & then
+        GroupMemberException exception = assertThrows(GroupMemberException.class, () -> groupInfoService.joinRequestHandler(adminEmail, request));
+        assertThat(exception.getMessage()).isEqualTo(ExceptionMessage.GROUP_MEMBER_STATUS_NOT_WAITING.getText());
+
+    }
+
+    @Test
+    @DisplayName("해당 그룹의 그룹장이 아닐 경우 예외가 발생한다.")
+    void joinResponseGroupMemberRoleIsNotAdmin() {
+        // given
+        // Admin이 아닌 그룹 멤버
+        User notAdmin = userRepository.save(User.builder()
+                .platformId("11")
+                .platformType(UserPlatformType.KAKAO)
+                .role(UserRole.USER)
+                .name("test")
+                .email("test@test.com")
+                .phoneNumber("010-1233-0000")
+                .profileImageUrl("https://google.com")
+                .pushAlarmYn(true)
+                .build());
+        GroupInfo groupInfo = groupInfoRepository.save(generateGroupInfo(notAdmin));
+        groupMemberRepository.save(generateGroupMember(notAdmin, groupInfo));
+
+        // WAITING 상태의 그룹 멤버
+        User requestUser = userRepository.save(generateUser());
+        GroupMember requestMember = GroupMember.builder()
+                .groupInfo(groupInfo)
+                .role(GroupMemberRole.GROUP_MEMBER)
+                .status(GroupMemberStatus.WAITING)
+                .user(requestUser)
+                .build();
+        GroupMember requestWaitingMember = groupMemberRepository.save(requestMember);
+
+        GroupInfoRegisterRequest request = GroupInfoRegisterRequest.builder()
+                .groupMemberId(requestWaitingMember.getId())
+                .groupId(groupInfo.getId())
+                .status(true)
+                .build();
+
+        // when & then
+        GroupMemberException exception = assertThrows(GroupMemberException.class, () -> groupInfoService.joinRequestHandler(notAdmin.getEmail(), request));
+        assertThat(exception.getMessage()).isEqualTo(ExceptionMessage.GROUP_MEMBER_ROLE_NOT_ADMIN.getText());
+
+    }
+
+    @Test
+    @DisplayName("status가 true일 경우 그룹 가입 요청이 승인되어 그룹 가입 요청자의 상태가 ACCEPT로 변경된다.")
+    void joinRequestStatusIsTrue() {
+        // Admin
+        User admin = userRepository.save(generateUser());
+        GroupInfo groupInfo = groupInfoRepository.save(generateGroupInfo(admin));
+
+        GroupMember adminMember = GroupMember.builder()
+                .groupInfo(groupInfo)
+                .role(GroupMemberRole.GROUP_ADMIN)
+                .status(GroupMemberStatus.ACCEPT)
+                .user(admin)
+                .build();
+        groupMemberRepository.save(adminMember);
+
+        // WAITING 상태의 그룹 멤버
+        User requestUser = userRepository.save(User.builder()
+                .platformId("11")
+                .platformType(UserPlatformType.KAKAO)
+                .role(UserRole.USER)
+                .name("test")
+                .email("test@test.com")
+                .phoneNumber("010-1233-0000")
+                .profileImageUrl("https://google.com")
+                .pushAlarmYn(true)
+                .build());
+        GroupMember requestMember = GroupMember.builder()
+                .groupInfo(groupInfo)
+                .role(GroupMemberRole.GROUP_MEMBER)
+                .status(GroupMemberStatus.WAITING)
+                .user(requestUser)
+                .build();
+        GroupMember requestWaitingMember = groupMemberRepository.save(requestMember);
+
+        GroupInfoRegisterRequest request = GroupInfoRegisterRequest.builder()
+                .groupMemberId(requestWaitingMember.getId())
+                .groupId(groupInfo.getId())
+                .status(true)
+                .build();
+
+        // when
+        groupInfoService.joinRequestHandler(admin.getEmail(), request);
+
+
+        // then
+        GroupMember updateMember = groupMemberRepository.findById(requestWaitingMember.getId()).get();
+        assertThat(updateMember.getStatus()).isEqualTo(GroupMemberStatus.ACCEPT);
+    }
+
+    @Test
+    @DisplayName("status가 false일 경우 그룹 가입 요청이 거절되어 그룹 가입 요청자의 상태가 WITHDRAW로 변경된다.")
+    void joinRequestStatusIsFalse() {
+        // Admin
+        User admin = userRepository.save(generateUser());
+        GroupInfo groupInfo = groupInfoRepository.save(generateGroupInfo(admin));
+
+        GroupMember adminMember = GroupMember.builder()
+                .groupInfo(groupInfo)
+                .role(GroupMemberRole.GROUP_ADMIN)
+                .status(GroupMemberStatus.ACCEPT)
+                .user(admin)
+                .build();
+        groupMemberRepository.save(adminMember);
+
+        // WAITING 상태의 그룹 멤버
+        User requestUser = userRepository.save(User.builder()
+                .platformId("11")
+                .platformType(UserPlatformType.KAKAO)
+                .role(UserRole.USER)
+                .name("test")
+                .email("test@test.com")
+                .phoneNumber("010-1233-0000")
+                .profileImageUrl("https://google.com")
+                .pushAlarmYn(true)
+                .build());
+        GroupMember requestMember = GroupMember.builder()
+                .groupInfo(groupInfo)
+                .role(GroupMemberRole.GROUP_MEMBER)
+                .status(GroupMemberStatus.WAITING)
+                .user(requestUser)
+                .build();
+        GroupMember requestWaitingMember = groupMemberRepository.save(requestMember);
+
+        GroupInfoRegisterRequest request = GroupInfoRegisterRequest.builder()
+                .groupMemberId(requestWaitingMember.getId())
+                .groupId(groupInfo.getId())
+                .status(false)
+                .build();
+
+        // when
+        groupInfoService.joinRequestHandler(admin.getEmail(), request);
+
+
+        // then
+        GroupMember updateMember = groupMemberRepository.findById(requestWaitingMember.getId()).get();
+        assertThat(updateMember.getStatus()).isEqualTo(GroupMemberStatus.WITHDRAW);
+    }
+
 }

--- a/heachi-core/housework-api/src/test/java/com/heachi/housework/api/service/group/info/GroupInfoServiceTest.java
+++ b/heachi-core/housework-api/src/test/java/com/heachi/housework/api/service/group/info/GroupInfoServiceTest.java
@@ -5,6 +5,7 @@ import com.heachi.admin.common.exception.group.info.GroupInfoException;
 import com.heachi.admin.common.exception.group.member.GroupMemberException;
 import com.heachi.housework.TestConfig;
 import com.heachi.housework.api.controller.group.info.request.GroupInfoRegisterRequest;
+import com.heachi.housework.api.controller.group.info.request.GroupInfoRegisterRequestStatusEnum;
 import com.heachi.housework.api.service.group.info.response.GroupInfoUserGroupServiceResponse;
 import com.heachi.admin.common.exception.user.UserException;
 import com.heachi.housework.TestConfig;
@@ -289,7 +290,7 @@ class GroupInfoServiceTest extends TestConfig {
         GroupInfoRegisterRequest request = GroupInfoRegisterRequest.builder()
                 .groupMemberId(requestWaitingMember.getId())
                 .groupId(groupInfo.getId())
-                .status(false)
+                .status(GroupInfoRegisterRequestStatusEnum.REFUSE)
                 .build();
 
         // when & then
@@ -329,7 +330,7 @@ class GroupInfoServiceTest extends TestConfig {
         GroupInfoRegisterRequest request = GroupInfoRegisterRequest.builder()
                 .groupMemberId(requestWaitingMember.getId())
                 .groupId(groupInfo.getId())
-                .status(true)
+                .status(GroupInfoRegisterRequestStatusEnum.ACCEPT)
                 .build();
 
         // when & then
@@ -375,7 +376,7 @@ class GroupInfoServiceTest extends TestConfig {
         GroupInfoRegisterRequest request = GroupInfoRegisterRequest.builder()
                 .groupMemberId(requestWaitingMember.getId())
                 .groupId(groupInfo.getId())
-                .status(true)
+                .status(GroupInfoRegisterRequestStatusEnum.ACCEPT)
                 .build();
 
         // when
@@ -424,7 +425,7 @@ class GroupInfoServiceTest extends TestConfig {
         GroupInfoRegisterRequest request = GroupInfoRegisterRequest.builder()
                 .groupMemberId(requestWaitingMember.getId())
                 .groupId(groupInfo.getId())
-                .status(false)
+                .status(GroupInfoRegisterRequestStatusEnum.REFUSE)
                 .build();
 
         // when

--- a/heachi-domain-mysql/src/main/java/com/heachi/mysql/define/group/member/GroupMember.java
+++ b/heachi-domain-mysql/src/main/java/com/heachi/mysql/define/group/member/GroupMember.java
@@ -53,8 +53,13 @@ public class GroupMember extends BaseEntity {
         this.status = GroupMemberStatus.WAITING;
     }
 
-    // 그룹 가입 요청 수락 여부에 따른 update
-    public void updateStatus(GroupMemberStatus status) {
-        this.status = status;
+    // 그룹 가입 요청을 승인받았을 경우
+    public void acceptJoin() {
+        this.status = GroupMemberStatus.ACCEPT;
+    }
+
+    // 그룹 가입 요청을 거절당했을 경우
+    public void refuseJoin() {
+        this.status = GroupMemberStatus.WITHDRAW;
     }
 }

--- a/heachi-domain-mysql/src/main/java/com/heachi/mysql/define/group/member/GroupMember.java
+++ b/heachi-domain-mysql/src/main/java/com/heachi/mysql/define/group/member/GroupMember.java
@@ -52,4 +52,9 @@ public class GroupMember extends BaseEntity {
         this.role = GroupMemberRole.GROUP_MEMBER;
         this.status = GroupMemberStatus.WAITING;
     }
+
+    // 그룹 가입 요청 수락 여부에 따른 update
+    public void updateStatus(GroupMemberStatus status) {
+        this.status = status;
+    }
 }

--- a/heachi-domain-mysql/src/main/java/com/heachi/mysql/define/group/member/repository/GroupMemberRepository.java
+++ b/heachi-domain-mysql/src/main/java/com/heachi/mysql/define/group/member/repository/GroupMemberRepository.java
@@ -4,6 +4,8 @@ import com.heachi.mysql.define.group.info.GroupInfo;
 import com.heachi.mysql.define.group.member.GroupMember;
 import com.heachi.mysql.define.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -13,5 +15,8 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long>,
 
     Optional<GroupMember> findByUserAndGroupInfo(User user, GroupInfo groupInfo);
 
-    Optional<GroupMember> findByIdAndGroupInfo(Long id, GroupInfo groupInfo);
+    Optional<GroupMember> findByUserAndGroupInfo_id(User user, Long groupId);
+
+    @Query("select gm from GROUP_MEMBER gm where gm.id = :id and gm.groupInfo.id = :groupId")
+    Optional<GroupMember> findByIdAndGroupInfoId(@Param("id")Long groupMemberId, @Param("groupId")Long groupId);
 }

--- a/heachi-domain-mysql/src/main/java/com/heachi/mysql/define/group/member/repository/GroupMemberRepository.java
+++ b/heachi-domain-mysql/src/main/java/com/heachi/mysql/define/group/member/repository/GroupMemberRepository.java
@@ -12,4 +12,6 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long>,
     Optional<GroupMember> findByUser(User user);
 
     Optional<GroupMember> findByUserAndGroupInfo(User user, GroupInfo groupInfo);
+
+    Optional<GroupMember> findByIdAndGroupInfo(Long id, GroupInfo groupInfo);
 }

--- a/heachi-domain-mysql/src/main/java/com/heachi/mysql/define/group/member/repository/GroupMemberRepositoryCustom.java
+++ b/heachi-domain-mysql/src/main/java/com/heachi/mysql/define/group/member/repository/GroupMemberRepositoryCustom.java
@@ -1,8 +1,10 @@
 package com.heachi.mysql.define.group.member.repository;
 
 import com.heachi.mysql.define.group.member.GroupMember;
+import com.heachi.mysql.define.user.User;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface GroupMemberRepositoryCustom {
 
@@ -14,5 +16,11 @@ public interface GroupMemberRepositoryCustom {
 
     // 그룹 멤버의 ID 리스트에 해당하는 그룹멤버들을 조회한다. (그룹원인 경우만 = ACCEPT) - 집안일 추가시 담당자 지정을 위해 필요
     public List<GroupMember> findGroupMemberListByGroupMemberIdList(List<Long> groupMemberIdList);
+
+    // 그룹 멤버의 ID와 User 정보를 이용해 그룹 멤버를 조회한다.
+    public Optional<GroupMember> findGroupMemberByGroupMemberIdAndGroupInfoId(Long groupMemberId, Long groupId);
+
+    // User의 email과 GroupId를 이용해 그룹 멤버를 조회한다.
+    public Optional<GroupMember> findGroupMemberByUserEmailAndGroupInfoId(String userEmail, Long groupId);
 
 }

--- a/heachi-domain-mysql/src/main/java/com/heachi/mysql/define/group/member/repository/GroupMemberRepositoryImpl.java
+++ b/heachi-domain-mysql/src/main/java/com/heachi/mysql/define/group/member/repository/GroupMemberRepositoryImpl.java
@@ -65,7 +65,7 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom {
                 .innerJoin(groupMember.groupInfo, groupInfo).fetchJoin()
                 .where(groupMember.id.eq(groupMemberId)
                         .and(groupMember.groupInfo.id.eq(groupId)))
-                .fetchFirst());
+                .fetchOne());
     }
 
     @Override
@@ -75,6 +75,6 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom {
                 .innerJoin(groupMember.groupInfo, groupInfo).fetchJoin()
                 .where(groupMember.user.email.eq(userEmail)
                         .and(groupMember.groupInfo.id.eq(groupId)))
-                .fetchFirst());
+                .fetchOne());
     }
 }

--- a/heachi-domain-mysql/src/main/java/com/heachi/mysql/define/group/member/repository/GroupMemberRepositoryImpl.java
+++ b/heachi-domain-mysql/src/main/java/com/heachi/mysql/define/group/member/repository/GroupMemberRepositoryImpl.java
@@ -3,12 +3,14 @@ package com.heachi.mysql.define.group.member.repository;
 import com.heachi.mysql.define.group.info.QGroupInfo;
 import com.heachi.mysql.define.group.member.GroupMember;
 import com.heachi.mysql.define.group.member.constant.GroupMemberStatus;
+import com.heachi.mysql.define.user.User;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Optional;
 
 import static com.heachi.mysql.define.group.info.QGroupInfo.*;
 import static com.heachi.mysql.define.group.member.QGroupMember.groupMember;
@@ -54,5 +56,25 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom {
                 .where(groupMember.id.in(groupMemberIdList)
                         .and(groupMember.status.eq(GroupMemberStatus.ACCEPT)))
                 .fetch();
+    }
+
+    @Override
+    public Optional<GroupMember> findGroupMemberByGroupMemberIdAndGroupInfoId(Long groupMemberId, Long groupId) {
+        // select gm from groupMember gm where gm.id= :groupMemberId and gm.groupInfo.id= :groupId
+        return Optional.of(queryFactory.selectFrom(groupMember)
+                .innerJoin(groupMember.groupInfo, groupInfo).fetchJoin()
+                .where(groupMember.id.eq(groupMemberId)
+                        .and(groupMember.groupInfo.id.eq(groupId)))
+                .fetchFirst());
+    }
+
+    @Override
+    public Optional<GroupMember> findGroupMemberByUserEmailAndGroupInfoId(String userEmail, Long groupId) {
+        return Optional.of(queryFactory.selectFrom(groupMember)
+                .innerJoin(groupMember.user, user).fetchJoin()
+                .innerJoin(groupMember.groupInfo, groupInfo).fetchJoin()
+                .where(groupMember.user.email.eq(userEmail)
+                        .and(groupMember.groupInfo.id.eq(groupId)))
+                .fetchFirst());
     }
 }

--- a/heachi-support/common/src/main/java/com/heachi/admin/common/exception/ExceptionMessage.java
+++ b/heachi-support/common/src/main/java/com/heachi/admin/common/exception/ExceptionMessage.java
@@ -45,6 +45,8 @@ public enum ExceptionMessage {
 
     // GroupMemberException
     GROUP_MEMBER_NOT_FOUND("그룹 멤버를 찾지 못했습니다."),
+    GROUP_MEMBER_STATUS_NOT_WAITING("그룹 가입 요청 수락 대기자가 아닙니다."),
+    GROUP_MEMBER_ROLE_NOT_ADMIN("그룹의 그룹장이 아닙니다."),
 
     // NotifyException
     NOTIFY_NOT_FOUND("해당 아이디의 알림을 찾을 수 없습니다."),


### PR DESCRIPTION
## 작업 내용
- [x] 수락 or 거절 선택에 따른 그룹 가입 요청 핸들링 API 구현


### 테스트
- [x] 그룹 가입 요청자의 상태가 WAITING이 아닐 경우 예외가 발생한다.
- [x] 해당 그룹의 그룹장이 아닐 경우 예외가 발생한다.
- [x] status가 true일 경우 그룹 가입 요청이 승인되어 그룹 가입 요청자의 상태가 ACCEPT로 변경된다.
- [x] status가 false일 경우 그룹 가입 요청이 거절되어 그룹 가입 요청자의 상태가 WITHDRAW로 변경된다.

<br/>


## 관련 이슈
#94 
