### PR TITLE
feat(#93) housework todo

### DIFF
--- a/heachi-core/housework-api/build.gradle
+++ b/heachi-core/housework-api/build.gradle
@@ -12,6 +12,7 @@ dependencies {
     implementation project(':heachi-support:common')
     implementation project(':heachi-support:logging')
     implementation project(':heachi-support:external-clients')
+    implementation project(':heachi-support:aws-s3') // aws s3 모듈
     implementation project(':heachi-domain-mysql')
     implementation project(':heachi-domain-redis')
 

--- a/heachi-core/housework-api/src/main/java/com/heachi/housework/api/controller/housework/todo/TodoController.java
+++ b/heachi-core/housework-api/src/main/java/com/heachi/housework/api/controller/housework/todo/TodoController.java
@@ -2,9 +2,13 @@ package com.heachi.housework.api.controller.housework.todo;
 
 import com.heachi.admin.common.response.JsonResult;
 import com.heachi.external.clients.auth.response.UserInfoResponse;
+import com.heachi.housework.api.controller.housework.todo.request.VerifyTodoRequest;
 import com.heachi.housework.api.service.auth.AuthExternalService;
 import com.heachi.housework.api.service.housework.todo.TodoService;
 import com.heachi.housework.api.service.housework.todo.request.TodoSelectRequest;
+import com.heachi.housework.api.service.housework.todo.request.VerifyTodoServiceRequest;
+import com.heachi.s3.api.service.AwsS3Service;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
@@ -19,6 +23,7 @@ public class TodoController {
 
     private final AuthExternalService authExternalService;
     private final TodoService todoService;
+    private final AwsS3Service awsS3Service;
 
     // Todo List 가져오기
     @GetMapping("/{groupId}")
@@ -29,5 +34,20 @@ public class TodoController {
 
         return JsonResult.successOf(todoService.cachedSelectTodo(
                 TodoSelectRequest.builder().groupId(groupId).date(date).build()));
+    }
+
+    // 집안일 인증하기
+    @PostMapping("/verify")
+    public JsonResult<?> verifyTodo(@RequestHeader(name = "Authorization") String authorization,
+                                    @Valid @ModelAttribute(name = "verifyTodoRequest") VerifyTodoRequest verifyTodoRequest) {
+        UserInfoResponse userInfo = authExternalService.userAuthenticateAndGroupMatch(authorization, verifyTodoRequest.getGroupId());
+        String uploadedImageURL = awsS3Service.uploadImage(verifyTodoRequest.getFile());
+        todoService.verifyTodo(VerifyTodoServiceRequest.builder()
+                .verifyImageURL(uploadedImageURL)
+                .todoId(verifyTodoRequest.getTodoId())
+                .email(userInfo.getEmail())
+                .build());
+
+        return JsonResult.successOf("사진이 정상적으로 저장되었습니다.");
     }
 }

--- a/heachi-core/housework-api/src/main/java/com/heachi/housework/api/controller/housework/todo/request/VerifyTodoRequest.java
+++ b/heachi-core/housework-api/src/main/java/com/heachi/housework/api/controller/housework/todo/request/VerifyTodoRequest.java
@@ -1,0 +1,22 @@
+package com.heachi.housework.api.controller.housework.todo.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@ToString
+@AllArgsConstructor
+public class VerifyTodoRequest {
+    @NotNull
+    private MultipartFile file; // (필수) 사진
+    @NotNull
+    private Long todoId;        // (필수) 집안일 아이디
+    @NotNull
+    private Long groupId;       // (필수) 그룹 아이디
+    private String comment;     // (선택) 사진에 대한 설명
+}

--- a/heachi-core/housework-api/src/main/java/com/heachi/housework/api/service/housework/todo/request/VerifyTodoServiceRequest.java
+++ b/heachi-core/housework-api/src/main/java/com/heachi/housework/api/service/housework/todo/request/VerifyTodoServiceRequest.java
@@ -1,0 +1,18 @@
+package com.heachi.housework.api.service.housework.todo.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class VerifyTodoServiceRequest {
+    private Long todoId;            // 집안일 아이디
+    private String email;           // 인증 요청 이메일
+    private String verifyImageURL;  // 인증 사진
+
+    @Builder
+    private VerifyTodoServiceRequest(Long todoId, String email, String verifyImageURL) {
+        this.todoId = todoId;
+        this.email = email;
+        this.verifyImageURL = verifyImageURL;
+    }
+}

--- a/heachi-core/housework-api/src/main/java/com/heachi/housework/api/service/housework/todo/response/TodoResponse.java
+++ b/heachi-core/housework-api/src/main/java/com/heachi/housework/api/service/housework/todo/response/TodoResponse.java
@@ -30,13 +30,13 @@ public class TodoResponse {
     private LocalDate date;
     private LocalTime endTime;
     private String verificationPhotoURL;
-    private String verifierId;
+    private Long verifierId;
     private LocalDateTime verificationTime;
 
     @Builder
     private TodoResponse(Long id, List<TodoUser> houseworkMembers, String category, String title, String detail,
                          Integer idx, HouseworkTodoStatus status, LocalDate date, LocalTime endTime,
-                         String verificationPhotoURL, String verifierId, LocalDateTime verificationTime) {
+                         String verificationPhotoURL, Long verifierId, LocalDateTime verificationTime) {
         this.id = id;
         this.houseworkMembers = houseworkMembers;
         this.category = category;

--- a/heachi-core/housework-api/src/test/java/com/heachi/housework/api/service/housework/todo/TodoServiceTest.java
+++ b/heachi-core/housework-api/src/test/java/com/heachi/housework/api/service/housework/todo/TodoServiceTest.java
@@ -2,6 +2,7 @@ package com.heachi.housework.api.service.housework.todo;
 
 import com.heachi.housework.TestConfig;
 import com.heachi.housework.api.service.housework.todo.request.TodoSelectRequest;
+import com.heachi.housework.api.service.housework.todo.request.VerifyTodoServiceRequest;
 import com.heachi.housework.api.service.housework.todo.response.TodoResponse;
 import com.heachi.housework.api.service.housework.todo.response.TodoUser;
 import com.heachi.mysql.define.group.info.GroupInfo;
@@ -14,6 +15,7 @@ import com.heachi.mysql.define.housework.info.HouseworkInfo;
 import com.heachi.mysql.define.housework.info.repository.HouseworkInfoRepository;
 import com.heachi.mysql.define.housework.member.HouseworkMember;
 import com.heachi.mysql.define.housework.member.repository.HouseworkMemberRepository;
+import com.heachi.mysql.define.housework.todo.HouseworkTodo;
 import com.heachi.mysql.define.housework.todo.constant.HouseworkTodoStatus;
 import com.heachi.mysql.define.housework.todo.repository.HouseworkTodoRepository;
 import com.heachi.mysql.define.user.User;
@@ -178,5 +180,50 @@ class TodoServiceTest extends TestConfig {
         assertThat(result.isDirtyBit()).isFalse();
         assertThat(result.getTodoList().size()).isEqualTo(2);
         System.out.println("result = " + result);
+    }
+
+    @Test
+    @DisplayName("Todo 담당자가 사진을 업로드하면 정상적으로 사진이 저장된다.")
+    void test5() {
+        // given
+        User user = userRepository.save(generateUser());
+        User user2 = userRepository.save(generateCustomUser("ghdcksgml1@naver.com", "010-1111-1111"));
+        User user3 = userRepository.save(generateCustomUser("ghdcksgml2@naver.com", "010-2222-2222"));
+        GroupInfo groupInfo = groupInfoRepository.save(generateGroupInfo(user));
+        GroupInfo groupInfo2 = groupInfoRepository.save(generateGroupInfo(user2));
+        GroupInfo groupInfo3 = groupInfoRepository.save(generateGroupInfo(user3));
+        GroupMember groupMember = groupMemberRepository.save(generateGroupMember(user, groupInfo));
+        groupMemberRepository.save(generateGroupMember(user2, groupInfo));
+        groupMemberRepository.save(generateGroupMember(user3, groupInfo));
+        groupMemberRepository.save(generateGroupMember(user, groupInfo3));
+        groupMemberRepository.save(generateGroupMember(user3, groupInfo2));
+
+        HouseworkCategory houseworkCategory = houseworkCategoryRepository.save(generateHouseworkCategory());
+        HouseworkInfo houseworkInfo = houseworkInfoRepository.save(generateHouseworkInfo(houseworkCategory));
+        HouseworkInfo houseworkInfo2 = houseworkInfoRepository.save(generateHouseworkInfo(houseworkCategory));
+        HouseworkInfo houseworkInfo3 = houseworkInfoRepository.save(generateHouseworkInfo(houseworkCategory));
+
+        HouseworkMember houseworkMember = houseworkMemberRepository.save(generateHouseworkMember(groupMember, houseworkInfo));
+        HouseworkInfo findHouseworkInfo = houseworkInfoRepository.findHouseworkInfoByIdJoinFetchHouseworkMembers(houseworkInfo.getId()).get();
+        HouseworkInfo findHouseworkInfo2 = houseworkInfoRepository.findHouseworkInfoByIdJoinFetchHouseworkMembers(houseworkInfo2.getId()).get();
+        HouseworkInfo findHouseworkInfo3 = houseworkInfoRepository.findHouseworkInfoByIdJoinFetchHouseworkMembers(houseworkInfo3.getId()).get();
+
+        HouseworkTodo houseworkTodo = houseworkTodoRepository.save(generateHouseworkTodo(findHouseworkInfo, groupInfo, LocalDate.now()));
+        HouseworkTodo houseworkTodo2 = houseworkTodoRepository.save(generateHouseworkTodo(findHouseworkInfo2, groupInfo2, LocalDate.now()));
+        HouseworkTodo houseworkTodo3 = houseworkTodoRepository.save(generateHouseworkTodo(findHouseworkInfo3, groupInfo3, LocalDate.now()));
+
+        String uploadedImageURL = "abcd.sfsa";
+
+        // when
+        todoService.verifyTodo(VerifyTodoServiceRequest.builder()
+                .verifyImageURL(uploadedImageURL)
+                .todoId(houseworkTodo.getId())
+                .email(user.getEmail())
+                .build());
+        HouseworkTodo findHouseworkTodo = houseworkTodoRepository.findById(houseworkTodo.getId()).get();
+
+        // then
+        assertThat(findHouseworkTodo.getVerificationPhotoURL()).isEqualTo(uploadedImageURL);
+        assertThat(findHouseworkTodo.getVerificationTime()).isNotNull();
     }
 }

--- a/heachi-domain-mysql/src/main/generated/com/heachi/mysql/define/housework/todo/QHouseworkTodo.java
+++ b/heachi-domain-mysql/src/main/generated/com/heachi/mysql/define/housework/todo/QHouseworkTodo.java
@@ -56,7 +56,7 @@ public class QHouseworkTodo extends EntityPathBase<HouseworkTodo> {
 
     public final DateTimePath<java.time.LocalDateTime> verificationTime = createDateTime("verificationTime", java.time.LocalDateTime.class);
 
-    public final StringPath verifierId = createString("verifierId");
+    public final NumberPath<Long> verifierId = createNumber("verifierId", Long.class);
 
     public QHouseworkTodo(String variable) {
         this(HouseworkTodo.class, forVariable(variable), INITS);

--- a/heachi-domain-mysql/src/main/java/com/heachi/mysql/define/group/member/repository/GroupMemberRepositoryCustom.java
+++ b/heachi-domain-mysql/src/main/java/com/heachi/mysql/define/group/member/repository/GroupMemberRepositoryCustom.java
@@ -3,6 +3,7 @@ package com.heachi.mysql.define.group.member.repository;
 import com.heachi.mysql.define.group.member.GroupMember;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface GroupMemberRepositoryCustom {
 
@@ -14,5 +15,8 @@ public interface GroupMemberRepositoryCustom {
 
     // 그룹 멤버의 ID 리스트에 해당하는 그룹멤버들을 조회한다. (그룹원인 경우만 = ACCEPT) - 집안일 추가시 담당자 지정을 위해 필요
     public List<GroupMember> findGroupMemberListByGroupMemberIdList(List<Long> groupMemberIdList);
+
+    // Email과 todoId를 통해 GroupMember를 조회한다.
+    public Optional<GroupMember> findGroupMemberByUserEmailAndTodoId(String email, Long todoId);
 
 }

--- a/heachi-domain-mysql/src/main/java/com/heachi/mysql/define/group/member/repository/GroupMemberRepositoryImpl.java
+++ b/heachi-domain-mysql/src/main/java/com/heachi/mysql/define/group/member/repository/GroupMemberRepositoryImpl.java
@@ -70,13 +70,14 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom {
                                         .from(houseworkTodo)
                                         .innerJoin(houseworkTodo.groupInfo, groupInfo)
                                         .where(houseworkTodo.id.eq(todoId)))
-                        .and(user.email.eq(email)));
+                        .and(user.email.eq(email)))
+                .fetchOne());
     }
                                    
     @Override
     public Optional<GroupMember> findGroupMemberByGroupMemberIdAndGroupInfoId(Long groupMemberId, Long groupId) {
         // select gm from groupMember gm where gm.id= :groupMemberId and gm.groupInfo.id= :groupId
-        return Optional.of(queryFactory.selectFrom(groupMember)
+        return Optional.ofNullable(queryFactory.selectFrom(groupMember)
                 .innerJoin(groupMember.groupInfo, groupInfo).fetchJoin()
                 .where(groupMember.id.eq(groupMemberId)
                         .and(groupMember.groupInfo.id.eq(groupId)))
@@ -85,7 +86,7 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom {
 
     @Override
     public Optional<GroupMember> findGroupMemberByUserEmailAndGroupInfoId(String userEmail, Long groupId) {
-        return Optional.of(queryFactory.selectFrom(groupMember)
+        return Optional.ofNullable(queryFactory.selectFrom(groupMember)
                 .innerJoin(groupMember.user, user).fetchJoin()
                 .innerJoin(groupMember.groupInfo, groupInfo).fetchJoin()
                 .where(groupMember.user.email.eq(userEmail)

--- a/heachi-domain-mysql/src/main/java/com/heachi/mysql/define/group/member/repository/GroupMemberRepositoryImpl.java
+++ b/heachi-domain-mysql/src/main/java/com/heachi/mysql/define/group/member/repository/GroupMemberRepositoryImpl.java
@@ -9,9 +9,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Optional;
 
 import static com.heachi.mysql.define.group.info.QGroupInfo.*;
 import static com.heachi.mysql.define.group.member.QGroupMember.groupMember;
+import static com.heachi.mysql.define.housework.todo.QHouseworkTodo.houseworkTodo;
 import static com.heachi.mysql.define.user.QUser.user;
 
 @Component
@@ -54,5 +56,20 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom {
                 .where(groupMember.id.in(groupMemberIdList)
                         .and(groupMember.status.eq(GroupMemberStatus.ACCEPT)))
                 .fetch();
+    }
+
+    @Override
+    public Optional<GroupMember> findGroupMemberByUserEmailAndTodoId(String email, Long todoId) {
+
+        return Optional.ofNullable(queryFactory
+                .selectFrom(groupMember)
+                .innerJoin(groupMember.user, user)
+                .where(groupMember.groupInfo.id.eq(
+                                JPAExpressions.select(groupInfo.id)
+                                        .from(houseworkTodo)
+                                        .innerJoin(houseworkTodo.groupInfo, groupInfo)
+                                        .where(houseworkTodo.id.eq(todoId)))
+                        .and(user.email.eq(email)))
+                .fetchOne());
     }
 }

--- a/heachi-domain-mysql/src/main/java/com/heachi/mysql/define/housework/info/repository/HouseworkInfoRepositoryImpl.java
+++ b/heachi-domain-mysql/src/main/java/com/heachi/mysql/define/housework/info/repository/HouseworkInfoRepositoryImpl.java
@@ -24,7 +24,7 @@ public class HouseworkInfoRepositoryImpl implements HouseworkInfoRepositoryCusto
     @Override
     public Optional<HouseworkInfo> findHouseworkInfoByIdJoinFetchHouseworkMembers(Long houseworkInfoId) {
 
-        return Optional.of(queryFactory.selectFrom(houseworkInfo)
+        return Optional.ofNullable(queryFactory.selectFrom(houseworkInfo)
                 .leftJoin(houseworkInfo.houseworkMembers, houseworkMember).fetchJoin()
                 .innerJoin(houseworkInfo.houseworkCategory, houseworkCategory).fetchJoin()
                 .where(houseworkInfo.id.eq(houseworkInfoId))

--- a/heachi-domain-mysql/src/main/java/com/heachi/mysql/define/housework/todo/HouseworkTodo.java
+++ b/heachi-domain-mysql/src/main/java/com/heachi/mysql/define/housework/todo/HouseworkTodo.java
@@ -69,7 +69,7 @@ public class HouseworkTodo extends BaseEntity {
     private String verificationPhotoURL;    // 다른 사용자가 확인할 수 있는 인증 사진 URL
 
     @Column(name = "VERIFIER_ID")
-    private String verifierId;              // 해당 집안일을 인증해준 사용자
+    private Long verifierId;              // 해당 집안일을 인증한 사용자 (GroupMemberId)
 
     @Column(name = "VERIFICATION_TIME")
     private LocalDateTime verificationTime; // 인증된 시각
@@ -77,7 +77,7 @@ public class HouseworkTodo extends BaseEntity {
     @Builder
     private HouseworkTodo(HouseworkInfo houseworkInfo, GroupInfo groupInfo, String houseworkMember, String category,
                          String title, String detail, Integer idx, HouseworkTodoStatus status, LocalDate date,
-                         LocalTime endTime, String verificationPhotoURL, String verifierId, LocalDateTime verificationTime) {
+                         LocalTime endTime, String verificationPhotoURL, Long verifierId, LocalDateTime verificationTime) {
         this.houseworkInfo = houseworkInfo;
         this.groupInfo = groupInfo;
         this.houseworkMember = houseworkMember;
@@ -91,6 +91,13 @@ public class HouseworkTodo extends BaseEntity {
         this.verificationPhotoURL = verificationPhotoURL;
         this.verifierId = verifierId;
         this.verificationTime = verificationTime;
+    }
+
+    // 집안일 인증
+    public void verifyHousework(String verificationPhotoURL, Long verifierId) {
+        this.verificationPhotoURL = verificationPhotoURL;
+        this.verifierId = verifierId;
+        this.verificationTime = LocalDateTime.now();
     }
 
     public static HouseworkTodo makeTodoReferInfo(HouseworkInfo houseworkInfo, GroupInfo groupInfo, LocalDate date) {

--- a/heachi-domain-mysql/src/main/java/com/heachi/mysql/define/housework/todo/repository/HouseworkTodoRepositoryCustom.java
+++ b/heachi-domain-mysql/src/main/java/com/heachi/mysql/define/housework/todo/repository/HouseworkTodoRepositoryCustom.java
@@ -1,11 +1,16 @@
 package com.heachi.mysql.define.housework.todo.repository;
 
+import com.heachi.mysql.define.housework.todo.HouseworkTodo;
 import com.heachi.mysql.define.housework.todo.repository.response.HouseworkTodoCount;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface HouseworkTodoRepositoryCustom {
 
     // groupInfoId 리스트를 받아 해당 그룹들의 오늘 날짜의 HouseworkTodo의 개수를 셀 수 있는 DTO를 반환하는 쿼리
     public List<HouseworkTodoCount> findHouseworkTodoCountByGroupInfoIdList(List<Long> groupInfoIdList);
+
+    // todoId와 groupMemberId를 통해 해당 그룹원이 해당 집안일의 담당자인지 확인한다.
+    public Optional<HouseworkTodo> findHouseworkTodoByIdAndGroupMemberId(Long todoId, Long groupMemberId);
 }

--- a/heachi-domain-mysql/src/main/java/com/heachi/mysql/define/housework/todo/repository/HouseworkTodoRepositoryImpl.java
+++ b/heachi-domain-mysql/src/main/java/com/heachi/mysql/define/housework/todo/repository/HouseworkTodoRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.heachi.mysql.define.housework.todo.repository;
 
+import com.heachi.mysql.define.housework.todo.HouseworkTodo;
 import com.heachi.mysql.define.housework.todo.repository.response.HouseworkTodoCount;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -7,10 +8,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 import static com.heachi.mysql.define.group.info.QGroupInfo.groupInfo;
+import static com.heachi.mysql.define.group.member.QGroupMember.groupMember;
 import static com.heachi.mysql.define.housework.todo.QHouseworkTodo.houseworkTodo;
+import static com.heachi.mysql.define.user.QUser.user;
 import static com.querydsl.core.group.GroupBy.groupBy;
 import static com.querydsl.core.group.GroupBy.list;
 
@@ -36,5 +41,21 @@ public class HouseworkTodoRepositoryImpl implements HouseworkTodoRepositoryCusto
                                 )
                         )
                 );
+    }
+
+    @Override
+    public Optional<HouseworkTodo> findHouseworkTodoByIdAndGroupMemberId(Long todoId, Long groupMemberId) {
+        HouseworkTodo findHouseworkTodo = queryFactory
+                .selectFrom(houseworkTodo)
+                .where(houseworkTodo.id.eq(todoId))
+                .fetchOne();
+
+        if (findHouseworkTodo != null) {
+            return Arrays.stream(findHouseworkTodo.getHouseworkMember().split(","))
+                    .map(Long::parseLong)
+                    .anyMatch(gmId -> gmId.equals(groupMemberId)) ? Optional.of(findHouseworkTodo) : Optional.empty();
+        } else {
+            return Optional.empty();
+        }
     }
 }

--- a/heachi-domain-mysql/src/main/java/com/heachi/mysql/define/housework/todo/repository/HouseworkTodoRepositoryImpl.java
+++ b/heachi-domain-mysql/src/main/java/com/heachi/mysql/define/housework/todo/repository/HouseworkTodoRepositoryImpl.java
@@ -50,7 +50,7 @@ public class HouseworkTodoRepositoryImpl implements HouseworkTodoRepositoryCusto
                 .where(houseworkTodo.id.eq(todoId))
                 .fetchOne();
 
-        if (findHouseworkTodo != null) {
+        if (findHouseworkTodo != null && !findHouseworkTodo.getHouseworkMember().isEmpty()) {
             return Arrays.stream(findHouseworkTodo.getHouseworkMember().split(","))
                     .map(Long::parseLong)
                     .anyMatch(gmId -> gmId.equals(groupMemberId)) ? Optional.of(findHouseworkTodo) : Optional.empty();

--- a/heachi-domain-mysql/src/test/java/com/heachi/mysql/define/group/member/repository/GroupMemberRepositoryTest.java
+++ b/heachi-domain-mysql/src/test/java/com/heachi/mysql/define/group/member/repository/GroupMemberRepositoryTest.java
@@ -6,6 +6,14 @@ import com.heachi.mysql.define.group.info.repository.GroupInfoRepository;
 import com.heachi.mysql.define.group.member.GroupMember;
 import com.heachi.mysql.define.group.member.constant.GroupMemberRole;
 import com.heachi.mysql.define.group.member.constant.GroupMemberStatus;
+import com.heachi.mysql.define.housework.category.HouseworkCategory;
+import com.heachi.mysql.define.housework.category.repository.HouseworkCategoryRepository;
+import com.heachi.mysql.define.housework.info.HouseworkInfo;
+import com.heachi.mysql.define.housework.info.repository.HouseworkInfoRepository;
+import com.heachi.mysql.define.housework.member.HouseworkMember;
+import com.heachi.mysql.define.housework.member.repository.HouseworkMemberRepository;
+import com.heachi.mysql.define.housework.todo.HouseworkTodo;
+import com.heachi.mysql.define.housework.todo.repository.HouseworkTodoRepository;
 import com.heachi.mysql.define.user.User;
 import com.heachi.mysql.define.user.constant.UserPlatformType;
 import com.heachi.mysql.define.user.constant.UserRole;
@@ -16,6 +24,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDate;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
@@ -32,8 +42,24 @@ class GroupMemberRepositoryTest extends TestConfig {
     @Autowired
     private GroupInfoRepository groupInfoRepository;
 
+    @Autowired
+    private HouseworkCategoryRepository houseworkCategoryRepository;
+
+    @Autowired
+    private HouseworkInfoRepository houseworkInfoRepository;
+
+    @Autowired
+    private HouseworkTodoRepository houseworkTodoRepository;
+
+    @Autowired
+    private HouseworkMemberRepository houseworkMemberRepository;
+
     @AfterEach
     void tearDown() {
+        houseworkTodoRepository.deleteAllInBatch();
+        houseworkMemberRepository.deleteAllInBatch();
+        houseworkInfoRepository.deleteAllInBatch();
+        houseworkCategoryRepository.deleteAllInBatch();
         groupMemberRepository.deleteAllInBatch();
         groupInfoRepository.deleteAllInBatch();
         userRepository.deleteAllInBatch();
@@ -52,5 +78,43 @@ class GroupMemberRepositoryTest extends TestConfig {
 
         // then
         assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("Email과 todoId를 통해 GroupMember를 조회한다.")
+    void findGroupMemberByUserEmailAndTodoId() {
+        // given
+        User user = userRepository.save(generateUser());
+        User user2 = userRepository.save(generateCustomUser("ghdcksgml1@naver.com", "010-1111-1111"));
+        User user3 = userRepository.save(generateCustomUser("ghdcksgml2@naver.com", "010-2222-2222"));
+        GroupInfo groupInfo = groupInfoRepository.save(generateGroupInfo(user));
+        GroupInfo groupInfo2 = groupInfoRepository.save(generateGroupInfo(user2));
+        GroupInfo groupInfo3 = groupInfoRepository.save(generateGroupInfo(user3));
+        GroupMember groupMember = groupMemberRepository.save(generateGroupMember(user, groupInfo));
+        groupMemberRepository.save(generateGroupMember(user2, groupInfo));
+        groupMemberRepository.save(generateGroupMember(user3, groupInfo));
+        groupMemberRepository.save(generateGroupMember(user, groupInfo3));
+        groupMemberRepository.save(generateGroupMember(user3, groupInfo2));
+
+        HouseworkCategory houseworkCategory = houseworkCategoryRepository.save(generateHouseworkCategory());
+        HouseworkInfo houseworkInfo = houseworkInfoRepository.save(generateHouseworkInfo(houseworkCategory));
+        HouseworkInfo houseworkInfo2 = houseworkInfoRepository.save(generateHouseworkInfo(houseworkCategory));
+        HouseworkInfo houseworkInfo3 = houseworkInfoRepository.save(generateHouseworkInfo(houseworkCategory));
+
+        HouseworkMember houseworkMember = houseworkMemberRepository.save(generateHouseworkMember(groupMember, houseworkInfo));
+        HouseworkInfo findHouseworkInfo = houseworkInfoRepository.findHouseworkInfoByIdJoinFetchHouseworkMembers(houseworkInfo.getId()).get();
+        HouseworkInfo findHouseworkInfo2 = houseworkInfoRepository.findHouseworkInfoByIdJoinFetchHouseworkMembers(houseworkInfo2.getId()).get();
+        HouseworkInfo findHouseworkInfo3 = houseworkInfoRepository.findHouseworkInfoByIdJoinFetchHouseworkMembers(houseworkInfo3.getId()).get();
+
+        HouseworkTodo houseworkTodo = houseworkTodoRepository.save(generateHouseworkTodo(findHouseworkInfo, groupInfo, LocalDate.now()));
+        HouseworkTodo houseworkTodo2 = houseworkTodoRepository.save(generateHouseworkTodo(findHouseworkInfo2, groupInfo2, LocalDate.now()));
+        HouseworkTodo houseworkTodo3 = houseworkTodoRepository.save(generateHouseworkTodo(findHouseworkInfo3, groupInfo3, LocalDate.now()));
+
+        // when
+        GroupMember findGroupMember = groupMemberRepository.findGroupMemberByUserEmailAndTodoId(user.getEmail(), houseworkTodo.getId()).get();
+
+        // then
+        assertThat(findGroupMember.getId()).isEqualTo(groupMember.getId());
+        assertThat(findGroupMember.getUser().getId()).isEqualTo(user.getId());
     }
 }

--- a/heachi-domain-mysql/src/test/java/com/heachi/mysql/define/housework/todo/repository/HouseworkTodoRepositoryTest.java
+++ b/heachi-domain-mysql/src/test/java/com/heachi/mysql/define/housework/todo/repository/HouseworkTodoRepositoryTest.java
@@ -20,6 +20,7 @@ import com.heachi.mysql.define.user.User;
 import com.heachi.mysql.define.user.constant.UserPlatformType;
 import com.heachi.mysql.define.user.constant.UserRole;
 import com.heachi.mysql.define.user.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -61,29 +62,15 @@ class HouseworkTodoRepositoryTest extends TestConfig {
     @Autowired
     private HouseworkMemberRepository houseworkMemberRepository;
 
-    @Test
-    @DisplayName("GroupInfoId와 Date를 이용해 값을 맵으로 조회한다.")
-    void findByGroupInfoAndDateReturnSetTest() {
-        // given
-        User user = userRepository.save(generateUser());
-        GroupInfo groupInfo = groupInfoRepository.save(generateGroupInfo(user));
-        GroupMember groupMember = groupMemberRepository.save(generateGroupMember(user, groupInfo));
-
-        HouseworkCategory houseworkCategory = houseworkCategoryRepository.save(generateHouseworkCategory());
-        HouseworkInfo houseworkInfo = houseworkInfoRepository.save(generateHouseworkInfo(houseworkCategory));
-
-        HouseworkMember houseworkMember = houseworkMemberRepository.save(generateHouseworkMember(groupMember, houseworkInfo));
-        HouseworkInfo findHouseworkInfo = houseworkInfoRepository.findHouseworkInfoByIdJoinFetchHouseworkMembers(houseworkInfo.getId()).get();
-
-        HouseworkTodo houseworkTodo = houseworkTodoRepository.save(generateHouseworkTodo(findHouseworkInfo, groupInfo, LocalDate.of(2022, 10, 10)));
-
-        // when
-        Map<Long, HouseworkTodo> result = houseworkTodoRepository.findByGroupInfoAndDate(groupInfo.getId(), LocalDate.of(2022, 10, 10))
-                .stream()
-                .collect(Collectors.toMap(obj -> obj.getId(), obj -> obj));
-
-        // then
-        assertThat(result.get(1L).getDate()).isEqualTo(LocalDate.of(2022, 10, 10));
+    @AfterEach
+    void tearDown() {
+        houseworkTodoRepository.deleteAllInBatch();
+        houseworkMemberRepository.deleteAllInBatch();
+        houseworkInfoRepository.deleteAllInBatch();
+        houseworkCategoryRepository.deleteAllInBatch();
+        groupMemberRepository.deleteAllInBatch();
+        groupInfoRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
     }
 
     @Test
@@ -121,5 +108,79 @@ class HouseworkTodoRepositoryTest extends TestConfig {
 
         // then
         assertThat(houseworkTodoCountByGroupInfoIdList.size()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("todoId와 email을 통해 해당 그룹원이 해당 집안일의 담당자인지 확인한다.")
+    void findHouseworkTodoByIdAndGroupMemberId() {
+        // given
+        User user = userRepository.save(generateUser());
+        User user2 = userRepository.save(generateCustomUser("ghdcksgml1@naver.com", "010-1111-1111"));
+        User user3 = userRepository.save(generateCustomUser("ghdcksgml2@naver.com", "010-2222-2222"));
+        GroupInfo groupInfo = groupInfoRepository.save(generateGroupInfo(user));
+        GroupInfo groupInfo2 = groupInfoRepository.save(generateGroupInfo(user2));
+        GroupInfo groupInfo3 = groupInfoRepository.save(generateGroupInfo(user3));
+        GroupMember groupMember = groupMemberRepository.save(generateGroupMember(user, groupInfo));
+        groupMemberRepository.save(generateGroupMember(user2, groupInfo));
+        groupMemberRepository.save(generateGroupMember(user3, groupInfo));
+        groupMemberRepository.save(generateGroupMember(user, groupInfo3));
+        groupMemberRepository.save(generateGroupMember(user3, groupInfo2));
+
+        HouseworkCategory houseworkCategory = houseworkCategoryRepository.save(generateHouseworkCategory());
+        HouseworkInfo houseworkInfo = houseworkInfoRepository.save(generateHouseworkInfo(houseworkCategory));
+        HouseworkInfo houseworkInfo2 = houseworkInfoRepository.save(generateHouseworkInfo(houseworkCategory));
+        HouseworkInfo houseworkInfo3 = houseworkInfoRepository.save(generateHouseworkInfo(houseworkCategory));
+
+        HouseworkMember houseworkMember = houseworkMemberRepository.save(generateHouseworkMember(groupMember, houseworkInfo));
+        HouseworkInfo findHouseworkInfo = houseworkInfoRepository.findHouseworkInfoByIdJoinFetchHouseworkMembers(houseworkInfo.getId()).get();
+        HouseworkInfo findHouseworkInfo2 = houseworkInfoRepository.findHouseworkInfoByIdJoinFetchHouseworkMembers(houseworkInfo2.getId()).get();
+        HouseworkInfo findHouseworkInfo3 = houseworkInfoRepository.findHouseworkInfoByIdJoinFetchHouseworkMembers(houseworkInfo3.getId()).get();
+
+        HouseworkTodo houseworkTodo = houseworkTodoRepository.save(generateHouseworkTodo(findHouseworkInfo, groupInfo, LocalDate.now()));
+        HouseworkTodo houseworkTodo2 = houseworkTodoRepository.save(generateHouseworkTodo(findHouseworkInfo2, groupInfo2, LocalDate.now()));
+        HouseworkTodo houseworkTodo3 = houseworkTodoRepository.save(generateHouseworkTodo(findHouseworkInfo3, groupInfo3, LocalDate.now()));
+
+        // when
+        HouseworkTodo findTodo = houseworkTodoRepository.findHouseworkTodoByIdAndGroupMemberId(houseworkTodo.getId(), groupMember.getId()).get();
+
+        // then
+        assertThat(findTodo.getHouseworkMember()).isEqualTo(String.valueOf(groupMember.getId()));
+    }
+
+    @Test
+    @DisplayName("todoId로 조회는 되지만 groupMemberId가 맞지 않는 경우 Optional.empty()를 반환한다.")
+    void findHouseworkTodoByIdAndGroupMemberIdFail() {
+        // given
+        User user = userRepository.save(generateUser());
+        User user2 = userRepository.save(generateCustomUser("ghdcksgml1@naver.com", "010-1111-1111"));
+        User user3 = userRepository.save(generateCustomUser("ghdcksgml2@naver.com", "010-2222-2222"));
+        GroupInfo groupInfo = groupInfoRepository.save(generateGroupInfo(user));
+        GroupInfo groupInfo2 = groupInfoRepository.save(generateGroupInfo(user2));
+        GroupInfo groupInfo3 = groupInfoRepository.save(generateGroupInfo(user3));
+        GroupMember groupMember = groupMemberRepository.save(generateGroupMember(user, groupInfo));
+        groupMemberRepository.save(generateGroupMember(user2, groupInfo));
+        groupMemberRepository.save(generateGroupMember(user3, groupInfo));
+        groupMemberRepository.save(generateGroupMember(user, groupInfo3));
+        groupMemberRepository.save(generateGroupMember(user3, groupInfo2));
+
+        HouseworkCategory houseworkCategory = houseworkCategoryRepository.save(generateHouseworkCategory());
+        HouseworkInfo houseworkInfo = houseworkInfoRepository.save(generateHouseworkInfo(houseworkCategory));
+        HouseworkInfo houseworkInfo2 = houseworkInfoRepository.save(generateHouseworkInfo(houseworkCategory));
+        HouseworkInfo houseworkInfo3 = houseworkInfoRepository.save(generateHouseworkInfo(houseworkCategory));
+
+        HouseworkMember houseworkMember = houseworkMemberRepository.save(generateHouseworkMember(groupMember, houseworkInfo));
+        HouseworkInfo findHouseworkInfo = houseworkInfoRepository.findHouseworkInfoByIdJoinFetchHouseworkMembers(houseworkInfo.getId()).get();
+        HouseworkInfo findHouseworkInfo2 = houseworkInfoRepository.findHouseworkInfoByIdJoinFetchHouseworkMembers(houseworkInfo2.getId()).get();
+        HouseworkInfo findHouseworkInfo3 = houseworkInfoRepository.findHouseworkInfoByIdJoinFetchHouseworkMembers(houseworkInfo3.getId()).get();
+
+        HouseworkTodo houseworkTodo = houseworkTodoRepository.save(generateHouseworkTodo(findHouseworkInfo, groupInfo, LocalDate.now()));
+        HouseworkTodo houseworkTodo2 = houseworkTodoRepository.save(generateHouseworkTodo(findHouseworkInfo2, groupInfo2, LocalDate.now()));
+        HouseworkTodo houseworkTodo3 = houseworkTodoRepository.save(generateHouseworkTodo(findHouseworkInfo3, groupInfo3, LocalDate.now()));
+
+        // when
+        var findTodo = houseworkTodoRepository.findHouseworkTodoByIdAndGroupMemberId(houseworkTodo.getId(), 2L);
+
+        // then
+        assertThat(findTodo.isEmpty()).isTrue();
     }
 }

--- a/heachi-support/common/src/main/java/com/heachi/admin/common/exception/ExceptionMessage.java
+++ b/heachi-support/common/src/main/java/com/heachi/admin/common/exception/ExceptionMessage.java
@@ -60,6 +60,7 @@ public enum ExceptionMessage {
     HOUSEWORK_ADD_FAIL("집안일 추가에 실패했습니다."),
     HOUSEWORK_ADD_PERMISSION_DENIED("집안일을 추가할 권한이 없습니다."),
     HOUSEWORK_CATEGORY_NOT_FOUND("집안일 카테고리 정보를 찾을 수 없습니다."),
+    HOUSEWORK_TODO_PERMISSION_DENIED("해당 집안일의 담당자가 아닙니다."),
     ;
 
     private final String text;


### PR DESCRIPTION
## 작업 내용
- [x] 집안일 사진 인증 API 구현


### 테스트
- [x] todoId로 조회는 되지만 groupMemberId가 맞지 않는 경우 Optional.empty()를 반환한다.
- [x] todoId와 email을 통해 해당 그룹원이 해당 집안일의 담당자인지 확인한다.
- [x] groupInfoId 리스트를 받아 해당 그룹들의 오늘 날짜의 HouseworkTodo의 개수를 셀 수 있는 DTO를 반환해준다.
- [x] Email과 todoId를 통해 GroupMember를 조회한다.
- [x] Todo 담당자가 사진을 업로드하면 정상적으로 사진이 저장된다.

<br/>


## 관련 이슈
#93